### PR TITLE
Tempelis: GitOps for Slack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/slack-infra
 go 1.12
 
 require (
-	github.com/bmatcuk/doublestar v1.1.1 // indirect
+	github.com/bmatcuk/doublestar v1.1.1
 	gopkg.in/yaml.v2 v2.2.2 // indirect
-	sigs.k8s.io/yaml v1.1.0 // indirect
+	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/bmatcuk/doublestar v1.1.1 h1:YroD6BJCZBYx06yYFEWvUuKVWQn3vLLQAVmDmvTSaiQ=
+github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
+sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/slack/calls.go
+++ b/slack/calls.go
@@ -1,0 +1,66 @@
+package slack
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ConversationType string
+
+const (
+	ConversationTypePublicChannel  ConversationType = "public_channel"
+	ConversationTypePrivateChannel ConversationType = "private_channel"
+	ConversationTypeIM             ConversationType = "im"
+	ConversationTypeMPIM           ConversationType = "mpip"
+)
+
+func (c *Client) GetConversations(types []ConversationType) ([]Conversation, error) {
+	t := make([]string, 0, len(types))
+	for _, v := range types {
+		t = append(t, string(v))
+	}
+
+	var conversations []Conversation
+	cursor := ""
+	for {
+		args := map[string]string{
+			"limit": "100",
+			"types": strings.Join(t, ","),
+		}
+		if cursor != "" {
+			args["cursor"] = cursor
+		}
+
+		ret := struct {
+			Channels []Conversation `json:"channels"`
+			Metadata struct {
+				NextCursor string `json:"next_cursor"`
+			} `json:"response_metadata"`
+		}{}
+
+		for {
+			if err := c.CallOldMethod("conversations.list", args, &ret); err != nil {
+				switch e := err.(type) {
+				case ErrRateLimit:
+					time.Sleep(e.Wait)
+					continue
+				default:
+					return nil, fmt.Errorf("failed to list conversations: %v", err)
+				}
+			}
+			break
+		}
+
+		conversations = append(conversations, ret.Channels...)
+		if ret.Metadata.NextCursor == "" {
+			break
+		}
+		cursor = ret.Metadata.NextCursor
+	}
+	return conversations, nil
+}
+
+func (c *Client) GetPublicChannels() ([]Conversation, error) {
+	return c.GetConversations([]ConversationType{ConversationTypePublicChannel})
+}

--- a/slack/calls.go
+++ b/slack/calls.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package slack
 
 import (

--- a/slack/types.go
+++ b/slack/types.go
@@ -57,17 +57,23 @@ type User struct {
 
 // Subteam represents a slack Subteam object.
 type Subteam struct {
-	ID          string `json:"id"`
-	IsUsergroup bool   `json:"is_usergroup"`
-	Name        string `json:"name"`
-	Handle      string `json:"handle"`
-	UserCount   int    `json:"user_count"`
-	UpdatedBy   string `json:"updated_by"`
-	CreatedBy   string `json:"created_by"`
-	DeletedBy   string `json:"deleted_by"`
-	CreateTime  int    `json:"date_create"`
-	UpdateTime  int    `json:"date_update"`
-	DeleteTime  int    `json:"date_delete"`
+	ID          string   `json:"id"`
+	IsUsergroup bool     `json:"is_usergroup"`
+	Name        string   `json:"name"`
+	Handle      string   `json:"handle"`
+	Description string   `json:"description"`
+	UserCount   int      `json:"user_count"`
+	UpdatedBy   string   `json:"updated_by"`
+	CreatedBy   string   `json:"created_by"`
+	DeletedBy   string   `json:"deleted_by"`
+	CreateTime  int      `json:"date_create"`
+	UpdateTime  int      `json:"date_update"`
+	DeleteTime  int      `json:"date_delete"`
+	Users       []string `json:"users"`
+	Prefs       struct {
+		Channels []string `json:"channels"`
+		Groups   []string `json:"groups"`
+	} `json:"prefs"`
 }
 
 // Conversation represents a slack Conversation object.

--- a/slack/types.go
+++ b/slack/types.go
@@ -80,9 +80,9 @@ type Subteam struct {
 type Conversation struct {
 	ID                 string        `json:"id"`
 	Name               string        `json:"name"`
-	IsChannel          bool          `json:"bool"`
-	IsGroup            bool          `json:"bool"`
-	IsIM               bool          `json:"bool"`
+	IsChannel          bool          `json:"is_channel"`
+	IsGroup            bool          `json:"is_group"`
+	IsIM               bool          `json:"is_im"`
 	Created            int64         `json:"created"`
 	Creator            string        `json:"creator"`
 	IsArchived         bool          `json:"is_archived"`

--- a/slack/types.go
+++ b/slack/types.go
@@ -57,23 +57,25 @@ type User struct {
 
 // Subteam represents a slack Subteam object.
 type Subteam struct {
-	ID          string   `json:"id"`
-	IsUsergroup bool     `json:"is_usergroup"`
-	Name        string   `json:"name"`
-	Handle      string   `json:"handle"`
-	Description string   `json:"description"`
-	UserCount   int      `json:"user_count"`
-	UpdatedBy   string   `json:"updated_by"`
-	CreatedBy   string   `json:"created_by"`
-	DeletedBy   string   `json:"deleted_by"`
-	CreateTime  int      `json:"date_create"`
-	UpdateTime  int      `json:"date_update"`
-	DeleteTime  int      `json:"date_delete"`
-	Users       []string `json:"users"`
-	Prefs       struct {
-		Channels []string `json:"channels"`
-		Groups   []string `json:"groups"`
-	} `json:"prefs"`
+	ID          string       `json:"id"`
+	IsUsergroup bool         `json:"is_usergroup"`
+	Name        string       `json:"name"`
+	Handle      string       `json:"handle"`
+	Description string       `json:"description"`
+	UserCount   int          `json:"user_count"`
+	UpdatedBy   string       `json:"updated_by"`
+	CreatedBy   string       `json:"created_by"`
+	DeletedBy   string       `json:"deleted_by"`
+	CreateTime  int          `json:"date_create"`
+	UpdateTime  int          `json:"date_update"`
+	DeleteTime  int          `json:"date_delete"`
+	Users       []string     `json:"users"`
+	Prefs       SubteamPrefs `json:"prefs"`
+}
+
+type SubteamPrefs struct {
+	Channels []string `json:"channels"`
+	Groups   []string `json:"groups"`
 }
 
 // Conversation represents a slack Conversation object.

--- a/slack/types.go
+++ b/slack/types.go
@@ -69,3 +69,41 @@ type Subteam struct {
 	UpdateTime  int    `json:"date_update"`
 	DeleteTime  int    `json:"date_delete"`
 }
+
+// Conversation represents a slack Conversation object.
+type Conversation struct {
+	ID                 string        `json:"id"`
+	Name               string        `json:"name"`
+	IsChannel          bool          `json:"bool"`
+	IsGroup            bool          `json:"bool"`
+	IsIM               bool          `json:"bool"`
+	Created            int64         `json:"created"`
+	Creator            string        `json:"creator"`
+	IsArchived         bool          `json:"is_archived"`
+	IsGeneral          bool          `json:"is_general"`
+	Unlinked           int           `json:"unlinked"`
+	NameNormalized     string        `json:"name_normalized"`
+	IsReadOnly         bool          `json:"is_read_only"`
+	IsShared           bool          `json:"is_shared"`
+	IsExtShared        bool          `json:"is_ext_shared"`
+	IsOrgShared        bool          `json:"is_org_shared"`
+	PendingShared      []interface{} ` json:"pending_shared"` // I have no idea what this is
+	IsPendingExtShared bool          `json:"is_pending_ext_shared"`
+	IsMember           bool          `json:"is_member"`
+	IsPrivate          bool          `json:"is_private"`
+	IsMPIM             bool          `json:"is_mpim"`
+	LastRead           string        `json:"last_read"`
+	Topic              struct {
+		Topic   string `json:"value"`
+		Creator string `json:"ID"`
+		LastSet int64  `json:"last_set"`
+	} `json:"topic"`
+	Purpose struct {
+		Purpose string `json:"value"`
+		Creator string `json:"ID"`
+		LastSet int64  `json:"last_set"`
+	} `json:"purpose"`
+	PreviousNames []string `json:"previous_names"`
+	NumMembers    int      `json:"num_members"`
+	Locale        string   `json:"locale"`
+}

--- a/tempelis/config/config.go
+++ b/tempelis/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -26,12 +27,25 @@ type Config struct {
 	Channels        []Channel         `json:"channels"`
 	Usergroups      []Usergroup       `json:"usergroups"`
 	ChannelTemplate ChannelTemplate   `json:"channel_template,omitempty"`
+	Restrictions    []Restrictions    `json:"restrictions"`
+}
+
+type Restrictions struct {
+	Path             string   `json:"path"`
+	Deny             bool     `json:"deny"`
+	Users            bool     `json:"users"`
+	ChannelsString   []string `json:"channels"`
+	UsergroupsString []string `json:"usergroups"`
+	Template         bool     `json:"template"`
+
+	Channels   []*regexp.Regexp
+	Usergroups []*regexp.Regexp
 }
 
 type Channel struct {
 	Name       string   `json:"name"`
 	ID         string   `json:"id,omitempty"`
-	Archived   bool     `json:"bool,omitempty"`
+	Archived   bool     `json:"archived,omitempty"`
 	Moderators []string `json:"moderators,omitempty"`
 }
 

--- a/tempelis/config/config.go
+++ b/tempelis/config/config.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package config
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Config struct {
 	Users           map[string]string `json:"users"`
 	Channels        []Channel         `json:"channels"`
@@ -43,4 +48,22 @@ type ChannelTemplate struct {
 	Pins    []string `json:"pins,omitempty"`
 	Topic   string   `json:"topic,omitempty"`
 	Purpose string   `json:"purpose,omitempty"`
+}
+
+// NamesToIDs converts a list of names to a list of slack user IDs
+func (c *Config) NamesToIDs(names []string) ([]string, error) {
+	result := make([]string, 0, len(names))
+	var missing []string
+	for _, n := range names {
+		if id, ok := c.Users[n]; ok {
+			result = append(result, id)
+		} else {
+			missing = append(missing, n)
+		}
+	}
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("unknown user names: %s", strings.Join(missing, ", "))
+	}
+	return result, nil
 }

--- a/tempelis/config/config.go
+++ b/tempelis/config/config.go
@@ -32,7 +32,6 @@ type Config struct {
 
 type Restrictions struct {
 	Path             string   `json:"path"`
-	Deny             bool     `json:"deny"`
 	Users            bool     `json:"users"`
 	ChannelsString   []string `json:"channels"`
 	UsergroupsString []string `json:"usergroups"`

--- a/tempelis/config/config.go
+++ b/tempelis/config/config.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 type Config struct {

--- a/tempelis/config/parser.go
+++ b/tempelis/config/parser.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/tempelis/config/parser.go
+++ b/tempelis/config/parser.go
@@ -85,6 +85,9 @@ func (p *Parser) Parse(reader io.Reader, path string) error {
 	p.Config.Usergroups = usergroups
 
 	if !isTemplateEmpty(c.ChannelTemplate) {
+		if !r.Template {
+			return fmt.Errorf("can't set channel template in %s", r.Path)
+		}
 		if !isTemplateEmpty(p.Config.ChannelTemplate) {
 			return errors.New("can't overwrite existing channel template")
 		}

--- a/tempelis/config/parser.go
+++ b/tempelis/config/parser.go
@@ -195,6 +195,9 @@ func matchesRegexList(s string, tests []*regexp.Regexp) bool {
 }
 
 func mergeUsers(target map[string]string, source map[string]string, r Restrictions) error {
+	if len(source) == 0 {
+		return nil
+	}
 	if !r.Users {
 		return fmt.Errorf("cannot define users in %q", r.Path)
 	}

--- a/tempelis/config/parser_test.go
+++ b/tempelis/config/parser_test.go
@@ -281,6 +281,13 @@ func TestMergeUsers(t *testing.T) {
 			restrictions: defaultRestriction,
 			expectErr:    true,
 		},
+		{
+			name:         "doing nothing is fine regardless of permissions",
+			a:            map[string]string{"Katharine": "U12345678"},
+			b:            map[string]string{},
+			restrictions: Restrictions{Users: false},
+			expected:     map[string]string{"Katharine": "U12345678"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/tempelis/config/parser_test.go
+++ b/tempelis/config/parser_test.go
@@ -1,0 +1,531 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestResolveRestrictions(t *testing.T) {
+	tests := []struct {
+		name         string
+		filePath     string
+		restrictions []Restrictions
+		expected     Restrictions
+	}{
+		{
+			name:     "no restrictions",
+			filePath: "whatever.yaml",
+			expected: defaultRestriction,
+		},
+		{
+			name:     "no restrictions match",
+			filePath: "not-specified.yaml",
+			restrictions: []Restrictions{
+				{
+					Path: "some-path.yaml",
+				},
+			},
+			expected: defaultRestriction,
+		},
+		{
+			name:     "simple restriction match",
+			filePath: "restricted.yaml",
+			restrictions: []Restrictions{
+				{
+					Path:  "restricted.yaml",
+					Users: true,
+				},
+			},
+			expected: Restrictions{
+				Path:  "restricted.yaml",
+				Users: true,
+			},
+		},
+		{
+			name:     "falls through to first matching restriction",
+			filePath: "second.yaml",
+			restrictions: []Restrictions{
+				{
+					Path:  "first.yaml",
+					Users: true,
+				},
+				{
+					Path: "second.yaml",
+				},
+				{
+					Path:     "third.yaml",
+					Template: true,
+				},
+			},
+			expected: Restrictions{
+				Path: "second.yaml",
+			},
+		},
+		{
+			name:     "doublestar matching works",
+			filePath: "some/very/nested/path.yaml",
+			restrictions: []Restrictions{
+				{
+					Path:  "**/*.yaml",
+					Users: true,
+				},
+			},
+			expected: Restrictions{
+				Path:  "**/*.yaml",
+				Users: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := resolveRestrictions(tc.restrictions, tc.filePath)
+			if !reflect.DeepEqual(r, tc.expected) {
+				t.Fatalf("Expected restriction %#v, got %#v", tc.expected, r)
+			}
+		})
+	}
+}
+
+func TestMergeRestrictions(t *testing.T) {
+	tests := []struct {
+		name      string
+		a         []Restrictions
+		b         []Restrictions
+		expected  []Restrictions
+		expectErr bool
+	}{
+		{
+			name: "replacing empty restrictions is permitted",
+			a:    nil,
+			b: []Restrictions{
+				{
+					Path: "foo.yaml",
+				},
+				{
+					Path: "bar.yaml",
+				},
+			},
+			expected: []Restrictions{
+				{
+					Path:       "foo.yaml",
+					Channels:   []*regexp.Regexp{},
+					Usergroups: []*regexp.Regexp{},
+				},
+				{
+					Path:       "bar.yaml",
+					Channels:   []*regexp.Regexp{},
+					Usergroups: []*regexp.Regexp{},
+				},
+			},
+		},
+		{
+			name: "replacing existing restrictions is prohibited",
+			a: []Restrictions{
+				{
+					Path: "foo.yaml",
+				},
+			},
+			b: []Restrictions{
+				{
+					Path:       "bar.yaml",
+					Channels:   []*regexp.Regexp{},
+					Usergroups: []*regexp.Regexp{},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "not replacing existing restrictions is fine",
+			a: []Restrictions{
+				{
+					Path: "foo.yaml",
+				},
+				{
+					Path: "bar.yaml",
+				},
+			},
+			b: nil,
+			expected: []Restrictions{
+				{
+					Path: "foo.yaml",
+				},
+				{
+					Path: "bar.yaml",
+				},
+			},
+		},
+		{
+			name: "regexes get parsed",
+			a:    nil,
+			b: []Restrictions{
+				{
+					Path:             "foo.yaml",
+					ChannelsString:   []string{"foo.*"},
+					UsergroupsString: []string{"bar.*"},
+				},
+			},
+			expected: []Restrictions{
+				{
+					Path:             "foo.yaml",
+					ChannelsString:   []string{"foo.*"},
+					UsergroupsString: []string{"bar.*"},
+					Channels:         []*regexp.Regexp{regexp.MustCompile("foo.*")},
+					Usergroups:       []*regexp.Regexp{regexp.MustCompile("bar.*")},
+				},
+			},
+		},
+		{
+			name: "invalid channel regexes are an error",
+			a:    nil,
+			b: []Restrictions{
+				{
+					Path:             "foo.yaml",
+					ChannelsString:   []string{"foo("},
+					UsergroupsString: []string{"bar.*"},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid usergroup regexes are an error",
+			a:    nil,
+			b: []Restrictions{
+				{
+					Path:             "foo.yaml",
+					ChannelsString:   []string{"foo"},
+					UsergroupsString: []string{"bar("},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := mergeRestrictions(tc.a, tc.b)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if tc.expectErr {
+				t.Fatalf("expected an error, but got result %#v", r)
+			}
+			if !reflect.DeepEqual(r, tc.expected) {
+				t.Fatalf("Expected restrictions %#v, got %#v", tc.expected, r)
+			}
+		})
+	}
+}
+
+func TestMergeUsers(t *testing.T) {
+	tests := []struct {
+		name         string
+		a            map[string]string
+		b            map[string]string
+		restrictions Restrictions
+		expected     map[string]string
+		expectErr    bool
+	}{
+		{
+			name:         "merging into an empty map works",
+			a:            map[string]string{},
+			b:            map[string]string{"Katharine": "U12345678", "bentheelder": "U23456789"},
+			restrictions: defaultRestriction,
+			expected:     map[string]string{"Katharine": "U12345678", "bentheelder": "U23456789"},
+		},
+		{
+			name:         "merging disjoint maps works",
+			a:            map[string]string{"Katharine": "U12345678"},
+			b:            map[string]string{"bentheelder": "U23456789"},
+			restrictions: defaultRestriction,
+			expected:     map[string]string{"Katharine": "U12345678", "bentheelder": "U23456789"},
+		},
+		{
+			name:         "merging overlapping maps is an error",
+			a:            map[string]string{"Katharine": "U12345678"},
+			b:            map[string]string{"Katharine": "U12345679", "bentheelder": "U23456789"},
+			restrictions: defaultRestriction,
+			expectErr:    true,
+		},
+		{
+			name:         "merging when not permitted is an error",
+			a:            map[string]string{},
+			b:            map[string]string{"Katharine": "U12345678"},
+			restrictions: Restrictions{Users: false},
+			expectErr:    true,
+		},
+		{
+			name:         "a name without a valid ID is an error",
+			a:            map[string]string{},
+			b:            map[string]string{"Katharine": "wat"},
+			restrictions: defaultRestriction,
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := map[string]string{}
+			for k, v := range tc.a {
+				a[k] = v
+			}
+			err := mergeUsers(a, tc.b, tc.restrictions)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if tc.expectErr {
+				t.Fatalf("expected an error, but got result %#v", a)
+			}
+			if !reflect.DeepEqual(a, tc.expected) {
+				t.Fatalf("Expected users %#v, got %#v", tc.expected, a)
+			}
+		})
+	}
+}
+
+func TestMergeChannels(t *testing.T) {
+	tests := []struct {
+		name         string
+		a            []Channel
+		b            []Channel
+		restrictions Restrictions
+		expected     []Channel
+		expectErr    bool
+	}{
+		{
+			name:         "merging first set works",
+			a:            nil,
+			b:            []Channel{{Name: "ponies"}, {Name: "kubernetes"}},
+			restrictions: defaultRestriction,
+			expected:     []Channel{{Name: "ponies"}, {Name: "kubernetes"}},
+		},
+		{
+			name:         "merging disjoint channels works",
+			a:            []Channel{{Name: "slack-admins"}},
+			b:            []Channel{{Name: "ponies"}, {Name: "kubernetes"}},
+			restrictions: defaultRestriction,
+			expected:     []Channel{{Name: "slack-admins"}, {Name: "ponies"}, {Name: "kubernetes"}},
+		},
+		{
+			name:         "merging overlapping channels fails",
+			a:            []Channel{{Name: "slack-admins"}, {Name: "ponies"}},
+			b:            []Channel{{Name: "ponies"}, {Name: "kubernetes"}},
+			restrictions: defaultRestriction,
+			expectErr:    true,
+		},
+		{
+			name:         "merging fails when all channels are forbidden",
+			a:            []Channel{{Name: "slack-admins"}},
+			b:            []Channel{{Name: "ponies"}, {Name: "kubernetes"}},
+			restrictions: Restrictions{},
+			expectErr:    true,
+		},
+		{
+			name:         "merging fails when no regexes match a new channel",
+			a:            []Channel{{Name: "slack-admins"}},
+			b:            []Channel{{Name: "ponies"}, {Name: "kubernetes"}},
+			restrictions: Restrictions{Channels: []*regexp.Regexp{regexp.MustCompile("ponies?")}},
+			expectErr:    true,
+		},
+		{
+			name:         "merging succeeds when a regex matches all new channels",
+			a:            []Channel{{Name: "slack-admins"}},
+			b:            []Channel{{Name: "ponies"}, {Name: "kubernetes"}},
+			restrictions: Restrictions{Channels: []*regexp.Regexp{regexp.MustCompile("ponies?"), regexp.MustCompile("kube.*")}},
+			expected:     []Channel{{Name: "slack-admins"}, {Name: "ponies"}, {Name: "kubernetes"}},
+		},
+		{
+			name:         "a channel without a name is illegal",
+			a:            nil,
+			b:            []Channel{{}},
+			restrictions: defaultRestriction,
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := mergeChannels(tc.a, tc.b, tc.restrictions)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if tc.expectErr {
+				t.Fatalf("expected an error, but got result %#v", r)
+			}
+			if !reflect.DeepEqual(r, tc.expected) {
+				t.Fatalf("Expected channels %#v, got %#v", tc.expected, r)
+			}
+		})
+	}
+}
+
+func TestMergeUsergroups(t *testing.T) {
+	group1 := Usergroup{
+		Name:        "pony-fans",
+		Members:     []string{"U12345678"},
+		LongName:    "Pony Fans",
+		Description: "Fans of ponies",
+	}
+	group2 := Usergroup{
+		Name:        "sig-testing",
+		Members:     []string{"U11111111", "U22222222", "U33333333"},
+		LongName:    "SIG Testing",
+		Description: "prow, mostly.",
+	}
+	tests := []struct {
+		name         string
+		a            []Usergroup
+		b            []Usergroup
+		restrictions Restrictions
+		expected     []Usergroup
+		expectErr    bool
+	}{
+		{
+			name:         "merging first set works",
+			a:            nil,
+			b:            []Usergroup{group1, group2},
+			restrictions: defaultRestriction,
+			expected:     []Usergroup{group1, group2},
+		},
+		{
+			name:         "merging disjoint sets works",
+			a:            []Usergroup{group1},
+			b:            []Usergroup{group2},
+			restrictions: defaultRestriction,
+			expected:     []Usergroup{group1, group2},
+		},
+		{
+			name:      "merging overlapping groups fails",
+			a:         []Usergroup{group2},
+			b:         []Usergroup{group1, group2},
+			expectErr: true,
+		},
+		{
+			name:         "merging fails when all groups are forbidden",
+			a:            nil,
+			b:            []Usergroup{group1},
+			restrictions: Restrictions{},
+			expectErr:    true,
+		},
+		{
+			name:         "merging fails when no regexes match a new group",
+			a:            nil,
+			b:            []Usergroup{group1},
+			restrictions: Restrictions{Usergroups: []*regexp.Regexp{regexp.MustCompile("sig.*")}},
+			expectErr:    true,
+		},
+		{
+			name:         "merging passes when all groups match a regex",
+			a:            nil,
+			b:            []Usergroup{group1, group2},
+			restrictions: Restrictions{Usergroups: []*regexp.Regexp{regexp.MustCompile("sig.*"), regexp.MustCompile("pony|ponies")}},
+			expected:     []Usergroup{group1, group2},
+		},
+		{
+			name: "a usergroup missing a name is an error",
+			a:    nil,
+			b: []Usergroup{{
+				Members:     []string{"U11111111"},
+				LongName:    "SIG Testing",
+				Description: "prow, mostly.",
+			}},
+			restrictions: defaultRestriction,
+			expectErr:    true,
+		},
+		{
+			name: "a usergroup missing a long name is an error",
+			a:    nil,
+			b: []Usergroup{{
+				Members:     []string{"U11111111"},
+				Name:        "sig-testing",
+				Description: "prow, mostly.",
+			}},
+			restrictions: defaultRestriction,
+			expectErr:    true,
+		},
+		{
+			name: "a usergroup missing a description is an error",
+			a:    nil,
+			b: []Usergroup{{
+				Members:  []string{"U11111111"},
+				Name:     "sig-testing",
+				LongName: "SIG Testing",
+			}},
+			restrictions: defaultRestriction,
+			expectErr:    true,
+		},
+		{
+			name: "a usergroup with no members is an error",
+			a:    nil,
+			b: []Usergroup{{
+				Members:     []string{},
+				Name:        "sig-testing",
+				LongName:    "SIG Testing",
+				Description: "prow, mostly.",
+			}},
+			restrictions: defaultRestriction,
+			expectErr:    true,
+		},
+		{
+			name: "an externally-managed usergroup only needs a name",
+			a:    nil,
+			b: []Usergroup{{
+				Name:     "sig-testing",
+				External: true,
+			}},
+			restrictions: defaultRestriction,
+			expected:     []Usergroup{{Name: "sig-testing", External: true}},
+		},
+		{
+			name:         "an externally-managed usergroup with no name is an error",
+			a:            nil,
+			b:            []Usergroup{{External: true}},
+			restrictions: defaultRestriction,
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := mergeUsergroups(tc.a, tc.b, tc.restrictions)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if tc.expectErr {
+				t.Fatalf("expected an error, but got result %#v", r)
+			}
+			if !reflect.DeepEqual(r, tc.expected) {
+				t.Fatalf("Expected usergroups %#v, got %#v", tc.expected, r)
+			}
+		})
+	}
+}

--- a/tempelis/main.go
+++ b/tempelis/main.go
@@ -1,20 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
-import "flag"
+import (
+	"flag"
+	"log"
+	"os"
+
+	"sigs.k8s.io/slack-infra/slack"
+	"sigs.k8s.io/slack-infra/tempelis/config"
+	"sigs.k8s.io/slack-infra/tempelis/reconciler"
+)
 
 type options struct {
-	DryRun bool
-	Config string
+	dryRun     bool
+	config     string
+	authConfig string
 }
 
 func parseOptions() options {
 	var o options
-	flag.BoolVar(&o.DryRun, "dry-run", true, "does nothing if true (which is the default)")
-	flag.StringVar(&o.Config, "config", "", "path to a configuration file, or directory of files")
+	flag.BoolVar(&o.dryRun, "dry-run", true, "does nothing if true (which is the default)")
+	flag.StringVar(&o.config, "config", "", "path to a configuration file, or directory of files")
+	flag.StringVar(&o.authConfig, "auth", "", "path to slack auth")
 	flag.Parse()
 	return o
 }
 
 func main() {
+	o := parseOptions()
 
+	sc, err := slack.LoadConfig(o.authConfig)
+	if err != nil {
+		log.Fatalf("Failed to load slack auth config: %v.\n", err)
+	}
+
+	stat, err := os.Stat(o.config)
+	if err != nil {
+		log.Fatalf("Failed to stat %s: %v\n", o.config, err)
+	}
+	var c config.Config
+	if stat.IsDir() {
+		c, err = config.ParseDir(o.config)
+	} else {
+		c, err = config.ParseFile(o.config)
+	}
+	if err != nil {
+		log.Fatalf("Failed to load config: %v\n", err)
+	}
+
+	r := reconciler.New(slack.New(sc), c)
+	if err := r.Reconcile(o.dryRun); err != nil {
+		log.Fatalf("Reconciliation failed: %v\n", err)
+	}
 }

--- a/tempelis/reconciler/channels.go
+++ b/tempelis/reconciler/channels.go
@@ -56,7 +56,11 @@ func (r *Reconciler) reconcileChannels() ([]Action, []error) {
 			}
 			delete(missingChannels, o.Name)
 		} else {
-			actions = append(actions, createChannelAction{name: c.Name})
+			if c.Archived {
+				errors = append(errors, fmt.Errorf("channel %s is new but already marked as archived, which is not permitted", c.Name))
+			} else {
+				actions = append(actions, createChannelAction{name: c.Name})
+			}
 		}
 	}
 

--- a/tempelis/reconciler/channels.go
+++ b/tempelis/reconciler/channels.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/slack-infra/slack"
+)
+
+func (r *Reconciler) reconcileChannels() ([]Action, []error) {
+	channels, err := r.slack.GetPublicChannels()
+	if err != nil {
+		return nil, []error{fmt.Errorf("failed to get current channel list: %v", err)}
+	}
+	channelsByName := map[string]slack.Conversation{}
+	channelsByID := map[string]slack.Conversation{}
+	missingChannels := map[string]slack.Conversation{}
+
+	var actions []Action
+	var errors []error
+
+	for _, c := range channels {
+		channelsByName[c.Name] = c
+		channelsByID[c.ID] = c
+		missingChannels[c.Name] = c
+	}
+
+	for _, c := range r.config.Channels {
+		if c.ID != "" {
+			if o, ok := channelsByID[c.ID]; ok {
+				if o.Name != c.Name {
+					actions = append(actions, renameChannelAction{id: o.ID, oldName: o.Name, newName: c.Name})
+					delete(missingChannels, o.Name)
+				}
+			} else {
+				errors = append(errors, fmt.Errorf("channel ID %s (for channel named %s) specified, but not known to Slack", c.ID, c.Name))
+			}
+		}
+		if o, ok := channelsByName[c.Name]; ok {
+			if c.Archived && !o.IsArchived {
+				actions = append(actions, archiveChannelAction{id: o.ID, name: o.Name})
+			} else if !c.Archived && o.IsArchived {
+				actions = append(actions, unarchiveChannelAction{id: o.ID, name: o.Name})
+			}
+			delete(missingChannels, o.Name)
+		} else {
+			actions = append(actions, createChannelAction{name: c.Name})
+		}
+	}
+
+	for _, o := range missingChannels {
+		errors = append(errors, fmt.Errorf("channel %s (%s) not referenced in config", o.Name, o.ID))
+	}
+
+	return actions, errors
+}
+
+type createChannelAction struct {
+	name string
+}
+
+func (a createChannelAction) Describe() string {
+	return fmt.Sprintf("Create new channel: %s", a.name)
+}
+
+func (a createChannelAction) Perform(reconciler *Reconciler) error {
+	c := slack.Conversation{}
+	if err := reconciler.slack.CallMethod("conversations.create", map[string]string{"name": a.name}, &c); err != nil {
+		return fmt.Errorf("failed to create channel: %v", err)
+	}
+	t := &reconciler.config.ChannelTemplate
+	if t.Topic != "" {
+		if err := reconciler.slack.CallMethod("conversations.setTopic", map[string]string{"channel": c.ID, "topic": t.Topic}, nil); err != nil {
+			return fmt.Errorf("failed to set topic of channel %s to %q: %v", c.Name, t.Topic, err)
+		}
+	}
+	if t.Purpose != "" {
+		if err := reconciler.slack.CallMethod("conversations.setPurpose", map[string]interface{}{"channel": c.ID, "purpose": t.Purpose}, nil); err != nil {
+			return fmt.Errorf("failed to set purpose of channel %s to %q: %v", c.Name, c.Topic, err)
+		}
+	}
+	for _, p := range t.Pins {
+		message := struct {
+			Channel   string `json:"channel"`
+			Text      string `json:"text"`
+			AsUser    bool   `json:"as_user"`
+			LinkNames bool   `json:"link_names"`
+		}{
+			Channel:   c.ID,
+			Text:      p,
+			AsUser:    false,
+			LinkNames: true,
+		}
+		r := struct {
+			TS string `json:"ts"`
+		}{}
+		if err := reconciler.slack.CallMethod("chat.postMessage", message, &r); err != nil {
+			return fmt.Errorf("failed to send message: %v", err)
+		}
+		if err := reconciler.slack.CallMethod("pins.add", map[string]string{"channel": c.ID, "timestamp": r.TS}, nil); err != nil {
+			return fmt.Errorf("failed to pin message %s in %s: %v", r.TS, c.Name, err)
+		}
+	}
+	return nil
+}
+
+type unarchiveChannelAction struct {
+	id   string
+	name string
+}
+
+func (a unarchiveChannelAction) Describe() string {
+	return fmt.Sprintf("Unarchive channel: %s", a.name)
+}
+
+func (a unarchiveChannelAction) Perform(reconciler *Reconciler) error {
+	if err := reconciler.slack.CallMethod("conversations.unarchive", map[string]string{"channel": a.id}, nil); err != nil {
+		return fmt.Errorf("failed to unarchive channel %s (%s): %v", a.id, a.name, err)
+	}
+	return nil
+}
+
+type archiveChannelAction struct {
+	id   string
+	name string
+}
+
+func (a archiveChannelAction) Describe() string {
+	return fmt.Sprintf("Archive channel: %s", a.name)
+}
+
+func (a archiveChannelAction) Perform(reconciler *Reconciler) error {
+	if err := reconciler.slack.CallMethod("conversations.archive", map[string]string{"channel": a.id}, nil); err != nil {
+		return fmt.Errorf("failed to archive channel %s (%s): %v", a.name, a.id, err)
+	}
+	return nil
+}
+
+type renameChannelAction struct {
+	id      string
+	oldName string
+	newName string
+}
+
+func (a renameChannelAction) Describe() string {
+	return fmt.Sprintf("Rename channel %s from %s to %s", a.id, a.oldName, a.newName)
+}
+
+func (a renameChannelAction) Perform(reconciler *Reconciler) error {
+	if err := reconciler.slack.CallMethod("conversations.rename", map[string]string{"channel": a.id, "name": a.newName}, nil); err != nil {
+		return fmt.Errorf("failed to rename channel %s (%s) to %s: %v", a.oldName, a.id, a.newName, err)
+	}
+	return nil
+}

--- a/tempelis/reconciler/channels_test.go
+++ b/tempelis/reconciler/channels_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/slack-infra/slack"
+	"sigs.k8s.io/slack-infra/tempelis/config"
+)
+
+func TestReconcileChannels(t *testing.T) {
+	tests := []struct {
+		name             string
+		priorChannels    []slack.Conversation
+		newChannels      []config.Channel
+		expectedActions  []Action
+		expectedErrCount int
+	}{
+		{
+			name:            "create a new channel",
+			priorChannels:   []slack.Conversation{{Name: "sig-testing", ID: "C12345678"}},
+			newChannels:     []config.Channel{{Name: "sig-testing"}, {Name: "sig-contribex"}},
+			expectedActions: []Action{createChannelAction{name: "sig-contribex"}},
+		},
+		{
+			name:            "archive a channel",
+			priorChannels:   []slack.Conversation{{Name: "sig-testing", ID: "C12345678"}},
+			newChannels:     []config.Channel{{Name: "sig-testing", Archived: true}},
+			expectedActions: []Action{archiveChannelAction{name: "sig-testing", id: "C12345678"}},
+		},
+		{
+			name:            "unarchive a channel",
+			priorChannels:   []slack.Conversation{{Name: "sig-testing", ID: "C12345678", IsArchived: true}},
+			newChannels:     []config.Channel{{Name: "sig-testing"}},
+			expectedActions: []Action{unarchiveChannelAction{name: "sig-testing", id: "C12345678"}},
+		},
+		{
+			name:          "do nothing to a channel that both is and should be archived",
+			priorChannels: []slack.Conversation{{Name: "sig-testing", ID: "C12345678", IsArchived: true}},
+			newChannels:   []config.Channel{{Name: "sig-testing", Archived: true}},
+		},
+		{
+			name:             "an extant channel not being mentioned is an error",
+			priorChannels:    []slack.Conversation{{Name: "sig-testing", ID: "C12345678"}},
+			newChannels:      []config.Channel{},
+			expectedErrCount: 1,
+		},
+		{
+			name:            "rename a channel",
+			priorChannels:   []slack.Conversation{{Name: "sig-testing", ID: "C12345678"}},
+			newChannels:     []config.Channel{{Name: "sig-ponies", ID: "C12345678"}},
+			expectedActions: []Action{renameChannelAction{id: "C12345678", oldName: "sig-testing", newName: "sig-ponies"}},
+		},
+		{
+			name:             "creating an archived channel is an error",
+			priorChannels:    []slack.Conversation{},
+			newChannels:      []config.Channel{{Name: "sig-ponies", Archived: true}},
+			expectedErrCount: 1,
+		},
+		{
+			name:             "simultaneously create, rename, archive, and unarchive channels, while reporting an error",
+			priorChannels:    []slack.Conversation{{Name: "sig-testing", ID: "C12345678"}, {Name: "sig-ponies", ID: "C11111111", IsArchived: true}, {Name: "sig-what", ID: "C22222222"}},
+			newChannels:      []config.Channel{{Name: "sig-hmm", ID: "C12345678", Archived: true}, {Name: "sig-ponies"}},
+			expectedActions:  []Action{renameChannelAction{id: "C12345678", oldName: "sig-testing", newName: "sig-hmm"}, archiveChannelAction{id: "C12345678", name: "sig-hmm"}, unarchiveChannelAction{id: "C11111111", name: "sig-ponies"}},
+			expectedErrCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Reconciler{
+				config:   config.Config{Channels: tc.newChannels},
+				channels: channelState{byID: map[string]*slack.Conversation{}, byName: map[string]*slack.Conversation{}},
+			}
+			for _, c := range tc.priorChannels {
+				c2 := c
+				r.channels.byID[c.ID] = &c2
+				r.channels.byName[c.Name] = &c2
+			}
+			actions, errs := r.reconcileChannels()
+			if !reflect.DeepEqual(actions, tc.expectedActions) {
+				t.Errorf("Expected actions: %#v\nActual actions: %#v", tc.expectedActions, actions)
+			}
+			if len(errs) != tc.expectedErrCount {
+				t.Errorf("Expected %d errors, but got %d: %v", tc.expectedErrCount, len(errs), errs)
+			}
+		})
+	}
+}

--- a/tempelis/reconciler/channelstate.go
+++ b/tempelis/reconciler/channelstate.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"fmt"
+	"sigs.k8s.io/slack-infra/slack"
+	"strings"
+)
+
+type channelState struct {
+	byName map[string]*slack.Conversation
+	byID   map[string]*slack.Conversation
+}
+
+func (c *channelState) init(s *slack.Client) error {
+	channels, err := s.GetPublicChannels()
+	if err != nil {
+		return err
+	}
+	for _, ch := range channels {
+		c.byName[ch.Name] = &ch
+		c.byID[ch.ID] = &ch
+	}
+	return nil
+}
+
+func (c *channelState) rename(old, new string) error {
+	if _, ok := c.byName[new]; ok {
+		return fmt.Errorf("can't rename %s to %s: name already used", old, new)
+	}
+	c.byName[old].Name = new
+	c.byName[new] = c.byName[old]
+	delete(c.byName, old)
+	return nil
+}
+
+func (c *channelState) create(name string) error {
+	if _, ok := c.byName[name]; ok {
+		return fmt.Errorf("can't create channel %s: name already used", name)
+	}
+	conversation := slack.Conversation{
+		Name:      name,
+		IsChannel: true,
+	}
+	c.byName[name] = &conversation
+	return nil
+}
+
+func (c *channelState) namesToIDs(names []string) ([]string, error) {
+	result := make([]string, 0, len(names))
+	var missing []string
+	for _, n := range names {
+		if r, ok := c.byName[n]; ok {
+			result = append(result, r.ID)
+		} else {
+			missing = append(missing, r.Name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("couldn't find channel IDs: %s", strings.Join(missing, ", "))
+	}
+	return result, nil
+}

--- a/tempelis/reconciler/channelstate.go
+++ b/tempelis/reconciler/channelstate.go
@@ -28,13 +28,16 @@ type channelState struct {
 }
 
 func (c *channelState) init(s *slack.Client) error {
+	c.byName = map[string]*slack.Conversation{}
+	c.byID = map[string]*slack.Conversation{}
 	channels, err := s.GetPublicChannels()
 	if err != nil {
 		return err
 	}
 	for _, ch := range channels {
-		c.byName[ch.Name] = &ch
-		c.byID[ch.ID] = &ch
+		ch2 := ch
+		c.byName[ch.Name] = &ch2
+		c.byID[ch.ID] = &ch2
 	}
 	return nil
 }
@@ -68,7 +71,7 @@ func (c *channelState) namesToIDs(names []string) ([]string, error) {
 		if r, ok := c.byName[n]; ok {
 			result = append(result, r.ID)
 		} else {
-			missing = append(missing, r.Name)
+			missing = append(missing, n)
 		}
 	}
 

--- a/tempelis/reconciler/reconciler.go
+++ b/tempelis/reconciler/reconciler.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"log"
+
+	"sigs.k8s.io/slack-infra/slack"
+	"sigs.k8s.io/slack-infra/tempelis/config"
+)
+
+type Reconciler struct {
+	slack  *slack.Client
+	config config.Config
+}
+
+func New(slack *slack.Client, config config.Config) *Reconciler {
+	return &Reconciler{
+		slack:  slack,
+		config: config,
+	}
+}
+
+func (r *Reconciler) Reconcile(dryRun bool) error {
+	var actions []Action
+	var errors []error
+	a, e := r.reconcileChannels()
+	actions = append(actions, a...)
+	errors = append(errors, e...)
+
+	for i, e := range errors {
+		log.Printf("Error %d: %v.\n", i+1, e)
+	}
+
+	for i, a := range actions {
+		log.Printf("Step %d: %s.\n", i+1, a.Describe())
+		if !dryRun {
+			if err := a.Perform(r); err != nil {
+				log.Printf("Failed: %v.\n", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+type Action interface {
+	Describe() string
+	Perform(reconciler *Reconciler) error
+}

--- a/tempelis/reconciler/usergroups.go
+++ b/tempelis/reconciler/usergroups.go
@@ -87,7 +87,9 @@ func (r *Reconciler) reconcileUsergroups() ([]Action, []error) {
 	}
 
 	for _, o := range missingGroups {
-		actions = append(actions, deactivateUsergroupAction{id: o.ID, handle: o.Handle})
+		if o.DeleteTime == 0 {
+			actions = append(actions, deactivateUsergroupAction{id: o.ID, handle: o.Handle})
+		}
 	}
 
 	return actions, errors

--- a/tempelis/reconciler/usergroups.go
+++ b/tempelis/reconciler/usergroups.go
@@ -70,7 +70,7 @@ func (r *Reconciler) reconcileUsergroups() ([]Action, []error) {
 			needsUpdate = needsUpdate || !stringSlicesEqual(targetChannels, o.Prefs.Channels)
 
 			if needsUpdate {
-				actions = append(actions, updateUsergroupAction{id: o.ID, description: g.Description, name: g.LongName, channelNames: g.Channels})
+				actions = append(actions, updateUsergroupAction{id: o.ID, handle: g.Name, description: g.Description, name: g.LongName, channelNames: g.Channels})
 			}
 
 			if !stringSlicesEqual(o.Users, targetIDs) {
@@ -98,10 +98,8 @@ func stringSlicesEqual(a []string, b []string) bool {
 		return false
 	}
 	for i := range a {
-		for j := range b {
-			if a[i] != b[j] {
-				return false
-			}
+		if a[i] != b[i] {
+			return false
 		}
 	}
 	return true

--- a/tempelis/reconciler/usergroups.go
+++ b/tempelis/reconciler/usergroups.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/slack-infra/slack"
+)
+
+func (r *Reconciler) reconcileUsergroups() ([]Action, []error) {
+	result := struct {
+		Usergroups []slack.Subteam `json:"usergroups"`
+	}{}
+	if err := r.slack.CallOldMethod("usergroups.list", map[string]string{"include_users": "true", "include_disabled": "true"}, &result); err != nil {
+		return nil, []error{fmt.Errorf("couldn't get usergroup list: %v", err)}
+	}
+
+	groupsByHandle := map[string]*slack.Subteam{}
+	missingGroups := map[string]*slack.Subteam{}
+
+	for _, g := range result.Usergroups {
+		groupsByHandle[g.Handle] = &g
+		missingGroups[g.Handle] = &g
+	}
+
+	var actions []Action
+	var errors []error
+	for _, g := range r.config.Usergroups {
+		delete(missingGroups, g.Name)
+		if o, ok := groupsByHandle[g.Name]; ok {
+			if g.External {
+				continue
+			}
+			// If we have a "deleted" group, but we found it here, it needs undeleting.
+			if o.DeleteTime > 0 {
+				actions = append(actions, reactivateUsergroupAction{id: o.ID, handle: o.Handle})
+			}
+
+			needsUpdate := false
+			targetIDs, err := r.config.NamesToIDs(g.Members)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("%s: %v", o.Name, err))
+				continue
+			}
+			sort.Strings(targetIDs)
+			sort.Strings(o.Users)
+
+			targetChannels, err := r.channels.namesToIDs(g.Channels)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("%s: %v", o.Name, err))
+				continue
+			}
+			sort.Strings(targetChannels)
+			sort.Strings(o.Prefs.Channels)
+
+			needsUpdate = needsUpdate || o.Name != g.LongName
+			needsUpdate = needsUpdate || o.Description != g.Description
+			needsUpdate = needsUpdate || !stringSlicesEqual(targetChannels, o.Prefs.Channels)
+
+			if needsUpdate {
+				actions = append(actions, updateUsergroupAction{id: o.ID, description: g.Description, name: g.LongName, channelNames: g.Channels})
+			}
+
+			if !stringSlicesEqual(o.Users, targetIDs) {
+				actions = append(actions, updateUsergroupMembersAction{id: o.ID, users: targetIDs})
+			}
+		} else {
+			targetIDs, err := r.config.NamesToIDs(g.Members)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("%s: %v", o.Name, err))
+				continue
+			}
+			actions = append(actions, updateUsergroupAction{id: o.ID, description: g.Description, name: g.LongName, channelNames: g.Channels, create: true}, updateUsergroupMembersAction{id: o.ID, users: targetIDs})
+		}
+	}
+
+	for _, o := range missingGroups {
+		actions = append(actions, deactivateUsergroupAction{id: o.ID, handle: o.Handle})
+	}
+
+	return actions, errors
+}
+
+func stringSlicesEqual(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		for j := range b {
+			if a[i] != b[j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+type deactivateUsergroupAction struct {
+	id     string
+	handle string
+}
+
+func (a deactivateUsergroupAction) Describe() string {
+	return fmt.Sprintf("Deactivate usergroup %s (%s)", a.handle, a.id)
+}
+
+func (a deactivateUsergroupAction) Perform(reconciler *Reconciler) error {
+	if err := reconciler.slack.CallMethod("usergroups.disable", map[string]string{"usergroup": a.id}, nil); err != nil {
+		return fmt.Errorf("failed to disable usergroup %s (%s): %v", a.handle, a.id, err)
+	}
+	return nil
+}
+
+type reactivateUsergroupAction struct {
+	id     string
+	handle string
+}
+
+func (a reactivateUsergroupAction) Describe() string {
+	return fmt.Sprintf("Reactivate usergroup: %s", a.handle)
+}
+
+func (a reactivateUsergroupAction) Perform(reconciler *Reconciler) error {
+	if err := reconciler.slack.CallMethod("usergroups.enable", map[string]string{"usergroup": a.id}, nil); err != nil {
+		return fmt.Errorf("failed to reactivate usergroup %s (%s): %v", a.handle, a.id, err)
+	}
+	return nil
+}
+
+type updateUsergroupAction struct {
+	id           string
+	description  string
+	name         string
+	channelNames []string
+	create       bool
+}
+
+func (a updateUsergroupAction) Describe() string {
+	return fmt.Sprintf("Unarchive channel: %s", a.name)
+}
+
+func (a updateUsergroupAction) Perform(reconciler *Reconciler) error {
+	channelIDs, err := reconciler.channels.namesToIDs(a.channelNames)
+	if err != nil {
+		return fmt.Errorf("couldn't find channel IDs for usergroup %s: %v", a.name, err)
+	}
+	for _, c := range channelIDs {
+		if c == "" {
+			return fmt.Errorf("unexpected empty channel ID when updating usergroup %s", a.name)
+		}
+	}
+
+	req := map[string]string{
+		"usergroup":   a.id,
+		"channels":    strings.Join(channelIDs, ","),
+		"description": a.description,
+		"name":        a.name,
+	}
+
+	action := "usergroups.update"
+	if a.create {
+		action = "usergroups.create"
+	}
+
+	if err := reconciler.slack.CallMethod(action, req, nil); err != nil {
+		return fmt.Errorf("failed to update usergroup %s (%s): %v", a.name, a.id, err)
+	}
+	return nil
+}
+
+type updateUsergroupMembersAction struct {
+	id    string
+	users []string
+}
+
+func (a updateUsergroupMembersAction) Describe() string {
+	return fmt.Sprintf("Set members of usergroup %s to %v", a.id, a.users)
+}
+
+func (a updateUsergroupMembersAction) Perform(reconciler *Reconciler) error {
+	if err := reconciler.slack.CallMethod("usergroups.users.update", map[string]string{"usergroup": a.id, "users": strings.Join(a.users, ",")}, nil); err != nil {
+		return fmt.Errorf("failed to update members of usergroup %s: %v", a.id, err)
+	}
+	return nil
+}

--- a/tempelis/reconciler/usergroups_test.go
+++ b/tempelis/reconciler/usergroups_test.go
@@ -83,6 +83,10 @@ func TestReconcileUsergroups(t *testing.T) {
 			newGroups:       []config.Usergroup{{Name: "pony-fans", LongName: "Pony Fans", Description: "Fans of ponies", Members: []string{"Katharine", "bentheelder"}}},
 			expectedActions: []Action{updateUsergroupMembersAction{id: "S12345678", name: "pony-fans", users: []string{"U11111111", "U12345678"}}},
 		},
+		{
+			name:        "don't try deleting and already-deleted group",
+			priorGroups: []slack.Subteam{{Handle: "pony-fans", ID: "S12345678", Name: "Pony Fans", Description: "Fans of ponies", Users: []string{"U12345678"}, DeleteTime: 10000}},
+		},
 	}
 
 	for _, tc := range tests {

--- a/tempelis/reconciler/usergroups_test.go
+++ b/tempelis/reconciler/usergroups_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/slack-infra/slack"
+	"sigs.k8s.io/slack-infra/tempelis/config"
+)
+
+func TestReconcileUsergroups(t *testing.T) {
+	userMapping := map[string]string{
+		"Katharine":   "U12345678",
+		"bentheelder": "U11111111",
+	}
+
+	tests := []struct {
+		name             string
+		priorGroups      []slack.Subteam
+		priorChannels    []slack.Conversation
+		newGroups        []config.Usergroup
+		expectedActions  []Action
+		expectedErrCount int
+	}{
+		{
+			name:      "creating a new simple group",
+			newGroups: []config.Usergroup{{Name: "pony-fans", LongName: "Pony Fans", Description: "Fans of ponies", Members: []string{"Katharine"}}},
+			expectedActions: []Action{
+				updateUsergroupAction{handle: "pony-fans", name: "Pony Fans", description: "Fans of ponies", create: true},
+				updateUsergroupMembersAction{name: "pony-fans", users: []string{"U12345678"}},
+			},
+		},
+		{
+			name:            "removing a group",
+			priorGroups:     []slack.Subteam{{Handle: "pony-fans", ID: "S12345678"}},
+			newGroups:       nil,
+			expectedActions: []Action{deactivateUsergroupAction{id: "S12345678", handle: "pony-fans"}},
+		},
+		{
+			name:            "updating a group's long name",
+			priorGroups:     []slack.Subteam{{Handle: "pony-fans", ID: "S12345678", Name: "Pon", Description: "Fans of ponies", Users: []string{"U12345678"}}},
+			newGroups:       []config.Usergroup{{Name: "pony-fans", LongName: "Pony Fans", Description: "Fans of ponies", Members: []string{"Katharine"}}},
+			expectedActions: []Action{updateUsergroupAction{id: "S12345678", handle: "pony-fans", name: "Pony Fans", description: "Fans of ponies"}},
+		},
+		{
+			name:            "updating a group's description",
+			priorGroups:     []slack.Subteam{{Handle: "pony-fans", ID: "S12345678", Name: "Pony Fans", Description: "an old description", Users: []string{"U12345678"}}},
+			newGroups:       []config.Usergroup{{Name: "pony-fans", LongName: "Pony Fans", Description: "Fans of ponies", Members: []string{"Katharine"}}},
+			expectedActions: []Action{updateUsergroupAction{id: "S12345678", handle: "pony-fans", name: "Pony Fans", description: "Fans of ponies"}},
+		},
+		{
+			name:            "updating a group's channel list",
+			priorChannels:   []slack.Conversation{{Name: "pony-channel"}},
+			priorGroups:     []slack.Subteam{{Handle: "pony-fans", ID: "S12345678", Name: "Pony Fans", Description: "an old description", Users: []string{"U12345678"}}},
+			newGroups:       []config.Usergroup{{Name: "pony-fans", LongName: "Pony Fans", Description: "Fans of ponies", Members: []string{"Katharine"}, Channels: []string{"pony-channel"}}},
+			expectedActions: []Action{updateUsergroupAction{id: "S12345678", handle: "pony-fans", name: "Pony Fans", description: "Fans of ponies", channelNames: []string{"pony-channel"}}},
+		},
+		{
+			name:          "doing nothing",
+			priorChannels: []slack.Conversation{{Name: "pony-channel", ID: "C22222222"}, {Name: "a-channel", ID: "C11111111"}},
+			priorGroups:   []slack.Subteam{{Handle: "pony-fans", ID: "S12345678", Name: "Pony Fans", Description: "Fans of ponies", Users: []string{"U12345678", "U11111111"}, Prefs: slack.SubteamPrefs{Channels: []string{"C11111111", "C22222222"}}}},
+			newGroups:     []config.Usergroup{{Name: "pony-fans", LongName: "Pony Fans", Description: "Fans of ponies", Members: []string{"bentheelder", "Katharine"}, Channels: []string{"pony-channel", "a-channel"}}},
+		},
+		{
+			name:            "updating a group's member list",
+			priorGroups:     []slack.Subteam{{Handle: "pony-fans", ID: "S12345678", Name: "Pony Fans", Description: "Fans of ponies", Users: []string{"U12345678"}}},
+			newGroups:       []config.Usergroup{{Name: "pony-fans", LongName: "Pony Fans", Description: "Fans of ponies", Members: []string{"Katharine", "bentheelder"}}},
+			expectedActions: []Action{updateUsergroupMembersAction{id: "S12345678", name: "pony-fans", users: []string{"U11111111", "U12345678"}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Reconciler{
+				config:   config.Config{Usergroups: tc.newGroups, Users: userMapping},
+				channels: channelState{byID: map[string]*slack.Conversation{}, byName: map[string]*slack.Conversation{}},
+				groups:   usergroupState{byID: map[string]*slack.Subteam{}, byHandle: map[string]*slack.Subteam{}},
+			}
+			for _, c := range tc.priorChannels {
+				c2 := c
+				r.channels.byID[c.ID] = &c2
+				r.channels.byName[c.Name] = &c2
+			}
+			for _, g := range tc.priorGroups {
+				g2 := g
+				r.groups.byHandle[g2.Handle] = &g2
+				r.groups.byID[g2.ID] = &g2
+			}
+			actions, errs := r.reconcileUsergroups()
+			if !reflect.DeepEqual(actions, tc.expectedActions) {
+				t.Errorf("Expected actions: %#v\nActual actions: %#v", tc.expectedActions, actions)
+			}
+			if len(errs) != tc.expectedErrCount {
+				t.Errorf("Expected %d errors, but got %d: %v", tc.expectedErrCount, len(errs), errs)
+			}
+		})
+	}
+}

--- a/tempelis/reconciler/usergroupstate.go
+++ b/tempelis/reconciler/usergroupstate.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"fmt"
+	"sigs.k8s.io/slack-infra/slack"
+)
+
+type usergroupState struct {
+	byHandle map[string]*slack.Subteam
+	byID     map[string]*slack.Subteam
+}
+
+func (u *usergroupState) init(s *slack.Client) error {
+	u.byHandle = map[string]*slack.Subteam{}
+	u.byID = map[string]*slack.Subteam{}
+
+	result := struct {
+		Usergroups []slack.Subteam `json:"usergroups"`
+	}{}
+	if err := s.CallOldMethod("usergroups.list", map[string]string{"include_users": "true", "include_disabled": "true"}, &result); err != nil {
+		return fmt.Errorf("couldn't get usergroup list: %v", err)
+	}
+
+	for _, ug := range result.Usergroups {
+		ug2 := ug
+		u.byHandle[ug.Handle] = &ug2
+		u.byID[ug.ID] = &ug2
+	}
+	return nil
+}
+
+func (u *usergroupState) create(handle string) error {
+	if _, ok := u.byHandle[handle]; ok {
+		return fmt.Errorf("can't create usergroup %s: name already used", handle)
+	}
+	g := slack.Subteam{
+		Handle: handle,
+	}
+	u.byHandle[handle] = &g
+	return nil
+}


### PR DESCRIPTION
This PR adds Tempelis, which reads a file or directory of configuration files and effects that change against a running Slack instance. It can run in "dry run" mode (the default) in which it just prints out what it would do, or it can actually do things.

Also see [the design doc](https://docs.google.com/document/d/1SUEzTD9BUmj5bXHtQ4yCtjWjqa1AXoCKOrR8Eb8VDwQ/edit) (requires kubernetes-dev).

This is a draft because a) I have literally not tested it at all, and also b) it could maybe use some unit tests

/cc @BenTheElder 