### PR TITLE
Move all the apps into a Kubernetes cluster

### DIFF
--- a/cluster/ingress.yaml
+++ b/cluster/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: ingress-new
+    networking.gke.io/managed-certificates: slack-k8s-io, slack-kubernetes-io
+spec:
+  backend:
+    serviceName: slackin2
+    servicePort: 80
+  rules:
+    - http:
+        paths:
+          - path: /infra/event-log/*
+            backend:
+              serviceName: slack-event-log
+              servicePort: 80
+          - path: /infra/moderator/*
+            backend:
+              serviceName: slack-moderator
+              servicePort: 80

--- a/cluster/slack-cert.yaml
+++ b/cluster/slack-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: slack-k8s-io
+spec:
+  domains:
+    - slack.k8s.io
+---
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: slack-kubernetes-io
+spec:
+  domains:
+    - slack.kubernetes.io

--- a/cluster/slack-event-log/deployment.yaml
+++ b/cluster/slack-event-log/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slack-event-log
+  labels:
+    app: slack-event-log
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: slack-event-log
+  template:
+    metadata:
+      labels:
+        app: slack-event-log
+    spec:
+      containers:
+      - name: slack-event-log
+        image: gcr.io/kubernetes-tools/slack-event-log:v20190415-bdf772f89
+        args:
+          - --config-path=/etc/slack-event-log/config.json
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        env:
+          - name: PATH_PREFIX
+            value: /infra/event-log
+        volumeMounts:
+        - mountPath: /etc/slack-event-log
+          name: config
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTP
+            port: 8080
+      volumes:
+      - name: config
+        secret:
+          secretName: slack-event-log-config

--- a/cluster/slack-event-log/service.yaml
+++ b/cluster/slack-event-log/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: slack-event-log
+spec:
+  selector:
+    app: slack-event-log
+  type: NodePort
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080

--- a/cluster/slack-moderator/deployment.yaml
+++ b/cluster/slack-moderator/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slack-moderator
+  labels:
+    app: slack-moderator
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: slack-moderator
+  template:
+    metadata:
+      labels:
+        app: slack-moderator
+    spec:
+      containers:
+      - name: slack-moderator
+        image: gcr.io/kubernetes-tools/slack-moderator:v20190415-bdf772f89
+        args:
+          - --config-path=/etc/slack-moderator/config.json
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        env:
+        - name: PATH_PREFIX
+          value: /infra/moderator
+        volumeMounts:
+        - mountPath: /etc/slack-moderator
+          name: config
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTP
+            port: 8080
+      volumes:
+      - name: config
+        secret:
+          secretName: slack-moderator-config

--- a/cluster/slack-moderator/service.yaml
+++ b/cluster/slack-moderator/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: slack-moderator
+spec:
+  selector:
+    app: slack-moderator
+  type: NodePort
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080

--- a/cluster/slackin/deployment.yaml
+++ b/cluster/slackin/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slackin-deployment
+  labels:
+    app: slackin2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: slackin2
+  template:
+    metadata:
+      labels:
+        app: slackin2
+    spec:
+      containers:
+      - name: slackin2
+        image: gcr.io/kubernetes-tools/slackin-kubernetes@sha256:d1a9b02239e690d5cbd78c76475a112aedf279dbd8ef401de1b8394f817a23b3
+        env:
+        - name: PORT
+          value: "80"
+        - name: SLACK_SUBDOMAIN
+          value: kubernetes
+        - name: SLACK_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: slackin-token
+        - name: BLOCKDOMAINS_SLACK_LIST
+          value: file:///etc/bad-domains/domains.txt
+        - name: GOOGLE_CAPTCHA_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret-key
+              name: recaptcha
+        - name: GOOGLE_CAPTCHA_SITEKEY
+          valueFrom:
+            secretKeyRef:
+              key: site-key
+              name: recaptcha
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/bad-domains
+          name: bad-domain-volume
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: bad-domains
+        name: bad-domain-volume

--- a/cluster/slackin/service.yaml
+++ b/cluster/slackin/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: slackin2
+spec:
+  selector:
+    app: slackin2
+  type: NodePort
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80

--- a/slack-event-log/Dockerfile
+++ b/slack-event-log/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+RUN apk update && apk add tzdata ca-certificates
+ADD slack-event-log /slack-event-log
+ENTRYPOINT ["/slack-event-log"]

--- a/slack-event-log/handlers/handlers.go
+++ b/slack-event-log/handlers/handlers.go
@@ -41,7 +41,7 @@ func New(client *slack.Client) *Handler {
 
 // HandleWebhook can be passed to http.HandlerFunc and will perform all processing associated with
 // Slack webhooks.
-func (h *Handler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		log.Printf(fmt.Sprintf("failed to read body: %v", err))

--- a/slack-event-log/main.go
+++ b/slack-event-log/main.go
@@ -38,10 +38,15 @@ func parseFlags() options {
 	return o
 }
 
+func handleHealthz(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("ok"))
+}
+
 func runServer(client *slack.Client) {
 	h := handlers.New(client)
 
 	http.HandleFunc("/webhook", h.HandleWebhook)
+	http.HandleFunc("/healthz", handleHealthz)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/slack-event-log/main.go
+++ b/slack-event-log/main.go
@@ -45,7 +45,7 @@ func handleHealthz(w http.ResponseWriter, r *http.Request) {
 func runServer(client *slack.Client) {
 	h := handlers.New(client)
 
-	http.HandleFunc("/webhook", h.HandleWebhook)
+	http.Handle(os.Getenv("PATH_PREFIX")+"/webhook", h)
 	http.HandleFunc("/healthz", handleHealthz)
 
 	port := os.Getenv("PORT")

--- a/slack-moderator/Dockerfile
+++ b/slack-moderator/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+RUN apk update && apk add tzdata ca-certificates
+ADD slack-moderator /slack-moderator
+ENTRYPOINT ["/slack-moderator"]

--- a/slack-moderator/main.go
+++ b/slack-moderator/main.go
@@ -39,7 +39,12 @@ func parseFlags() options {
 	return o
 }
 
+func handleHealthz(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("ok"))
+}
+
 func runServer(h *handler) error {
+	http.HandleFunc("/healthz", handleHealthz)
 	http.Handle("/webhook", h)
 
 	port := os.Getenv("PORT")

--- a/slack-moderator/main.go
+++ b/slack-moderator/main.go
@@ -45,7 +45,7 @@ func handleHealthz(w http.ResponseWriter, r *http.Request) {
 
 func runServer(h *handler) error {
 	http.HandleFunc("/healthz", handleHealthz)
-	http.Handle("/webhook", h)
+	http.Handle(os.Getenv("PATH_PREFIX")+"/webhook", h)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/slack-report-message/main.go
+++ b/slack-report-message/main.go
@@ -45,7 +45,7 @@ func runServer(sl *slack.Client) {
 	h := &handler{client: sl}
 
 	http.HandleFunc("/healthz", handleHealthz)
-	http.Handle("/webhook", h)
+	http.Handle(os.Getenv("PATH_PREFIX")+"/webhook", h)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/slack-report-message/main.go
+++ b/slack-report-message/main.go
@@ -37,9 +37,14 @@ func parseFlags() options {
 	return o
 }
 
+func handleHealthz(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("ok"))
+}
+
 func runServer(sl *slack.Client) {
 	h := &handler{client: sl}
 
+	http.HandleFunc("/healthz", handleHealthz)
 	http.Handle("/webhook", h)
 
 	port := os.Getenv("PORT")

--- a/slack-welcomer/main.go
+++ b/slack-welcomer/main.go
@@ -39,9 +39,14 @@ func parseFlags() options {
 	return o
 }
 
+func handleHealthz(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("ok"))
+}
+
 func runServer(sl *slack.Client, o options) {
 	h := &handler{client: sl, messagePath: o.messagePath}
 
+	http.HandleFunc("/healthz", handleHealthz)
 	http.Handle("/webhook", h)
 
 	port := os.Getenv("PORT")

--- a/slack-welcomer/main.go
+++ b/slack-welcomer/main.go
@@ -47,7 +47,7 @@ func runServer(sl *slack.Client, o options) {
 	h := &handler{client: sl, messagePath: o.messagePath}
 
 	http.HandleFunc("/healthz", handleHealthz)
-	http.Handle("/webhook", h)
+	http.Handle(os.Getenv("PATH_PREFIX")+"/webhook", h)
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
Currently everything lives on an AppEngine instance somewhere. Move them all into a Kubernetes cluster and include the configuration here. Also, for good measure, include the slackin configuration as currently running at slack.k8s.io.

This code and configuration is currently live and serving production.

(The underlying motivation here is being able to make changes to the moderation bot that would make its cold start time less than stellar.)

/cc @BenTheElder 