### PR TITLE
[WIP] Simple auto moderation service

### DIFF
--- a/slack-filter-moderator/.gitignore
+++ b/slack-filter-moderator/.gitignore
@@ -1,0 +1,3 @@
+slack-filter-moderator-chart
+# Go binary
+slack-filter-moderator

--- a/slack-filter-moderator/Dockerfile
+++ b/slack-filter-moderator/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/base
+ADD slack-filter-moderator /slack-filter-moderator
+ENTRYPOINT ["/slack-filter-moderator"]

--- a/slack-filter-moderator/main.go
+++ b/slack-filter-moderator/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"sigs.k8s.io/slack-infra/slack"
+	"time"
+)
+
+func handleHealthz(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("ok"))
+}
+
+func handleURLVerification(body []byte) ([]byte, error) {
+	request := struct {
+		Challenge string `json:"challenge"`
+	}{}
+	if err := json.Unmarshal(body, &request); err != nil {
+		return nil, fmt.Errorf("error parsing request: %v", err)
+	}
+	response := map[string]string{"challenge": request.Challenge}
+	return json.Marshal(response)
+}
+func parseFlags() options {
+	o := options{}
+	flag.StringVar(&o.configPath, "config-path", "config.json", "Path to a file containing the slack config")
+	flag.Parse()
+	return o
+}
+
+type options struct {
+	configPath string
+}
+
+func main() {
+	o := parseFlags()
+	fmt.Println(o.configPath)
+	c := slack.Config{
+		SigningSecret: os.Getenv("SIGNING_SECRET"),
+		WebhookURL:    os.Getenv("WEBHOOK_URL"),
+		AccessToken:   os.Getenv("ACCESS_TOKEN"),
+	}
+	s := slack.New(c)
+	publicChannels, _ := s.GetPublicChannels()
+	pretty, _ := json.MarshalIndent(publicChannels, "", "\t")
+	fmt.Println(string(pretty))
+
+	http.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {
+		t := time.Now()
+		fmt.Printf("\nnew request %s\n", t.Format(time.RFC3339))
+		defer r.Body.Close()
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+		}
+		var messageEvent slack.MessageChannelsEvent
+		json.Unmarshal(body, &messageEvent)
+		fmt.Println(string(body))
+		if messageEvent.Event.BotID != "" {
+			return
+		}
+		req := map[string]interface{}{
+			"channel": messageEvent.Event.Channel,
+			"text":    "pong",
+		}
+		err = s.CallMethod("chat.postMessage", req, nil)
+		if err != nil {
+			fmt.Println(err)
+		}
+		req = map[string]interface{}{
+			"channel":   messageEvent.Event.Channel,
+			"thread_ts": messageEvent.Event.Ts,
+			"text":      "pong",
+		}
+		err = s.CallMethod("chat.postMessage", req, nil)
+		if err != nil {
+			fmt.Println(err)
+		}
+		req = map[string]interface{}{
+			"channel": messageEvent.Event.User,
+			"text":    "pong",
+		}
+		err = s.CallMethod("chat.postMessage", req, nil)
+		if err != nil {
+			fmt.Println(err)
+		}
+		req = map[string]interface{}{
+			"channel": messageEvent.Event.Channel,
+			"user":    messageEvent.Event.User,
+			"text":    "pong",
+		}
+		err = s.CallMethod("chat.postEphemeral", req, nil)
+		if err != nil {
+			fmt.Println(err)
+		}
+		verification, err := handleURLVerification(body)
+		if err != nil {
+		}
+		w.Write(verification)
+	})
+
+	http.HandleFunc("/healthz", handleHealthz)
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/slack/types.go
+++ b/slack/types.go
@@ -115,3 +115,38 @@ type Conversation struct {
 	NumMembers    int      `json:"num_members"`
 	Locale        string   `json:"locale"`
 }
+
+// MessageChannelsEvent see here: https://api.slack.com/events/message.channels
+type MessageChannelsEvent struct {
+	Token    string `json:"token"`
+	TeamID   string `json:"team_id"`
+	APIAppID string `json:"api_app_id"`
+	Event    struct {
+		BotID      string `json:"bot_id"`
+		Type       string `json:"type"`
+		Text       string `json:"text"`
+		User       string `json:"user"`
+		Ts         string `json:"ts"`
+		Team       string `json:"team"`
+		BotProfile struct {
+			ID      string `json:"id"`
+			Deleted bool   `json:"deleted"`
+			Name    string `json:"name"`
+			Updated int    `json:"updated"`
+			AppID   string `json:"app_id"`
+			Icons   struct {
+				Image36 string `json:"image_36"`
+				Image48 string `json:"image_48"`
+				Image72 string `json:"image_72"`
+			} `json:"icons"`
+			TeamID string `json:"team_id"`
+		} `json:"bot_profile"`
+		Channel     string `json:"channel"`
+		EventTs     string `json:"event_ts"`
+		ChannelType string `json:"channel_type"`
+	} `json:"event"`
+	Type        string   `json:"type"`
+	EventID     string   `json:"event_id"`
+	EventTime   int      `json:"event_time"`
+	AuthedUsers []string `json:"authed_users"`
+}


### PR DESCRIPTION
In #slack-admins was the question if we would like to educate people about avoiding the usage of `guys` to address a group of people. 

Since I wanted to get more familiar with this project here anyway I decided to code up how this could look like.

We have a total of 4 methods of informing a user about this (Channel Response, Ephemeral, Private message and thread).
<img width="932" alt="Screenshot 2020-05-01 at 01 04 29" src="https://user-images.githubusercontent.com/3389721/80767756-f145a180-8b48-11ea-8d36-569db357ce83.png">

I see this also being related to #27 (@jeefy)

So since this is just a super simple PoC where I only tested how I can notify users I was wondering if we can make this a real feature configurable via yaml or json like this for example:
```yaml
- triggers:
  - guys
  action: Ephemeral
  message: May I suggest "all" instead when addessing a group of people? Thank you. :)
- triggers:
  - black
  - listed
  - words
  action: delete
  message: hey your message has been deleted because it violated the Kubernetes CoC.
- triggers: 
  - soft
  - black
  - listed
  - words
  action: report-to-mods
```
Triggers could also be a link to a raw gist word list for example.

Slack link:
https://kubernetes.slack.com/archives/C4M06S5HS/p1588103132093300