### PR TITLE
Changing len frm 9 to 11 to match new string count

### DIFF
--- a/tempelis/config/parser.go
+++ b/tempelis/config/parser.go
@@ -205,7 +205,7 @@ func mergeUsers(target map[string]string, source map[string]string, r Restrictio
 		if _, ok := target[k]; ok {
 			return fmt.Errorf("cannot overwrite users (duplicate user %s)", k)
 		}
-		if len(v) != 9 {
+		if len(v) != 9 && len(v) != 11 {
 			return fmt.Errorf("%s: %q is not a valid slack user ID", k, v)
 		}
 		target[k] = v

--- a/tempelis/config/parser_test.go
+++ b/tempelis/config/parser_test.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -249,28 +246,28 @@ func TestMergeUsers(t *testing.T) {
 		{
 			name:         "merging into an empty map works",
 			a:            map[string]string{},
-			b:            map[string]string{"Katharine": "U12345678", "bentheelder": "U23456789"},
+			b:            map[string]string{"Katharine": "U1234567890", "bentheelder": "U2345678901"},
 			restrictions: defaultRestriction,
-			expected:     map[string]string{"Katharine": "U12345678", "bentheelder": "U23456789"},
+			expected:     map[string]string{"Katharine": "U1234567890", "bentheelder": "U2345678901"},
 		},
 		{
 			name:         "merging disjoint maps works",
-			a:            map[string]string{"Katharine": "U12345678"},
-			b:            map[string]string{"bentheelder": "U23456789"},
+			a:            map[string]string{"Katharine": "U1234567890"},
+			b:            map[string]string{"bentheelder": "U2345678901"},
 			restrictions: defaultRestriction,
-			expected:     map[string]string{"Katharine": "U12345678", "bentheelder": "U23456789"},
+			expected:     map[string]string{"Katharine": "U1234567890", "bentheelder": "U2345678901"},
 		},
 		{
 			name:         "merging overlapping maps is an error",
-			a:            map[string]string{"Katharine": "U12345678"},
-			b:            map[string]string{"Katharine": "U12345679", "bentheelder": "U23456789"},
+			a:            map[string]string{"Katharine": "U1234567890"},
+			b:            map[string]string{"Katharine": "U1234567901", "bentheelder": "U2345678901"},
 			restrictions: defaultRestriction,
 			expectErr:    true,
 		},
 		{
 			name:         "merging when not permitted is an error",
 			a:            map[string]string{},
-			b:            map[string]string{"Katharine": "U12345678"},
+			b:            map[string]string{"Katharine": "U1234567890"},
 			restrictions: Restrictions{Users: false},
 			expectErr:    true,
 		},
@@ -283,10 +280,10 @@ func TestMergeUsers(t *testing.T) {
 		},
 		{
 			name:         "doing nothing is fine regardless of permissions",
-			a:            map[string]string{"Katharine": "U12345678"},
+			a:            map[string]string{"Katharine": "U1234567890"},
 			b:            map[string]string{},
 			restrictions: Restrictions{Users: false},
-			expected:     map[string]string{"Katharine": "U12345678"},
+			expected:     map[string]string{"Katharine": "U1234567890"},
 		},
 	}
 


### PR DESCRIPTION
Slack has changed the unique member ID from 9 to 11  characters. Over the weekend this test [failed](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/community/4787/pull-community-tempelis-check/1262382761520402432) This is the [pr](https://github.com/kubernetes/community/pull/4787) 
Signed-off-by: markyjackson-taulia <marky.r.jackson@gmail.com>