### PR TITLE
Replace Slack im API with conversations API

### DIFF
--- a/slack-welcomer/handler.go
+++ b/slack-welcomer/handler.go
@@ -124,14 +124,15 @@ func (h *handler) sendWelcome(uid string) error {
 		return fmt.Errorf("couldn't get welcome: %v", err)
 	}
 
-	// Slack requires that we first open an "IM channel" that we can then use to actually send messages.
+	// Slack requires that we first open a "conversation channel" that we can then use to actually send messages.
 	response := struct {
 		Channel struct {
 			ID string `json:"id"`
 		} `json:"channel"`
 	}{}
-	if err := h.client.CallMethod("im.open", map[string]string{"user": uid}, &response); err != nil {
-		return fmt.Errorf("couldn't open IM channel: %v", err)
+
+	if err := h.client.CallMethod("conversations.open", map[string]string{"users": uid}, &response); err != nil {
+		return fmt.Errorf("couldn't open a conversation channel: %v", err)
 	}
 	channel := response.Channel.ID
 


### PR DESCRIPTION
Fixes #37

Deprecation Notice: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api

Old API: https://api.slack.com/methods/im.open
New API: https://api.slack.com/methods/conversations.open

The API method which got deprecated is `im.open`. The method
(`conversations.open`) which replaces it also changes the request
parameters required.

The deprecated API (`im.open`) required a request parameter called `user`
whose value was the Slack user ID of the user that we intend to open a message
channel with.

The new API method (`conversations.open`) provisions for the request parameter
`users` which whose value needs to be a comma-separated list of up to 8 user IDs
with whom we intend to start a conversation.

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>