### PR TITLE
Add cpanato as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@
 reviewers:
   - Katharine
   - jeefy
+  - cpanato
 approvers:
   - Katharine
   - jeefy


### PR DESCRIPTION
In an effort to improve the bus factor for slack-infra, this commit
adds cpanato as a reviewer.

Carlos has written the `slack-moderator-words` bot and is familiar with
the code. Additionally, he's also been involved in driving the bot's
deployment so he's familiar with the k8s.io side for slack-infra too.

/assign @jeefy 
for approval

/assign @cpanato 
to confirm he's good with this