### PR TITLE
slack-moderator-words: Add feature to join to the public channels

### DIFF
--- a/slack-moderator-words/README.md
+++ b/slack-moderator-words/README.md
@@ -32,11 +32,14 @@ directory. It must look like this:
 slack-moderator-words requires the following OAuth scopes on its Slack app:
 
 - `channels:history`
+- `channels:join`
+- `channels:read`
 - `chat:write`
 - `chat:write.public`
 
 Additionally, slack-moderator-words also requires the following event subscriptions (Subscribe to events on behalf of users):
 
+- `channel_created`
 - `message.channels`
 
 slack-moderator-words does not require any interactive components.

--- a/slack-moderator-words/main.go
+++ b/slack-moderator-words/main.go
@@ -84,6 +84,25 @@ func main() {
 
 	s := slack.New(c)
 
+	// List all public channels and try to join.
+	// This is needed otherwise the bot cannot receive the events for the channels
+	// and cannot moderate it
+	channels, err := s.GetPublicChannels()
+	if err != nil {
+		log.Fatalf("Failed to list all public channels: %v", err)
+	}
+
+	for _, channel := range channels {
+		log.Printf("Public Channels: %s/%s\n", channel.ID, channel.Name)
+		req := map[string]interface{}{
+			"channel": channel.ID,
+		}
+		err = s.CallMethod("conversations.join", req, nil)
+		if err != nil {
+			log.Fatalf("Failed to join channel %s: %v", channel.Name, err)
+		}
+	}
+
 	h := &handler{client: s, filters: filters}
 	log.Fatal(runServer(h))
 }

--- a/slack-moderator-words/model/types.go
+++ b/slack-moderator-words/model/types.go
@@ -33,15 +33,22 @@ type SlackEvent struct {
 }
 
 type Event struct {
-	Type        string `json:"type"`
-	Channel     string `json:"channel"`
-	User        string `json:"user"`
-	Text        string `json:"text"`
-	TS          string `json:"ts"`
-	EventTS     string `json:"event_ts"`
-	ThreadTS    string `json:"thread_ts"`
-	ChannelType string `json:"channel_type"`
-	BotID       string `json:"bot_id"`
+	Type        string      `json:"type"`
+	Channel     interface{} `json:"channel"`
+	User        string      `json:"user"`
+	Text        string      `json:"text"`
+	TS          string      `json:"ts"`
+	EventTS     string      `json:"event_ts"`
+	ThreadTS    string      `json:"thread_ts"`
+	ChannelType string      `json:"channel_type"`
+	BotID       string      `json:"bot_id"`
+}
+
+type Channel struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Creator string `json:"creator"`
+	Created int    `json:"created"`
 }
 
 type FilterConfig []struct {


### PR DESCRIPTION
First of all, I want to apologize for the wrong assumptions I made, and when I did the initial implementation, I added a user token for my tests, and that works out of the box :( 
After some investigation realize we need to add the bot in the channels, we want to moderate.

### Issue:
There is no scope/event that makes the bot receive notifications for all public channels that the bot is not part of.
If we want to receive events from a public channel, the bot needs to be part of the specific channel.

### Options:
1. Add the bot manually for all public channels and add that for the new channels that will be created
2. Add some automation to make the bot self-aware of public channels

### Proposed solution:
When the app/bot starts, it lists all public channels and adds itself to those channels.
When a new channel is created, the bot will receive a notification and add itself to the new channel.

### Possible future work:
- Add a channel filter to the bot, skip those channels, and not join

### Demo:
https://share.getcloudapp.com/jkuL7rr1

/kind feature
/kind bug

/assign @nikhita @jeefy @mrbobbytables @ameukam 