### PR TITLE
tempelis: Add --validate flag for offline config validation

### DIFF
--- a/tempelis/main.go
+++ b/tempelis/main.go
@@ -29,6 +29,7 @@ import (
 
 type options struct {
 	dryRun       bool
+	validateOnly bool
 	config       string
 	restrictions string
 	authConfig   string
@@ -38,6 +39,7 @@ type options struct {
 func parseOptions() options {
 	var o options
 	flag.BoolVar(&o.dryRun, "dry-run", true, "does nothing if true (which is the default)")
+	flag.BoolVar(&o.validateOnly, "validate-only", false, "only validate config without connecting to Slack (useful for presubmits)")
 	flag.StringVar(&o.config, "config", "", "path to a configuration file, or directory of files")
 	flag.StringVar(&o.restrictions, "restrictions", "", "path to a configuration file containing restrictions")
 	flag.StringVar(&o.authConfig, "auth", "", "path to slack auth")
@@ -48,16 +50,6 @@ func parseOptions() options {
 
 func main() {
 	o := parseOptions()
-
-	var sc slack.Config
-	var err error
-
-	if !o.validate {
-		sc, err = slack.LoadConfig(o.authConfig)
-		if err != nil {
-			log.Fatalf("Failed to load slack auth config: %v.\n", err)
-		}
-	}
 
 	stat, err := os.Stat(o.config)
 	if err != nil {
@@ -80,9 +72,16 @@ func main() {
 		log.Fatalf("Failed to load config: %v\n", err)
 	}
 
-	if o.validate {
-		log.Println("Config valid!")
+	// If validate-only mode, just validate the config and exit
+	if o.validateOnly {
+		log.Println("Configuration validation successful!")
 		return
+	}
+
+	// Normal mode: load auth and reconcile
+	sc, err := slack.LoadConfig(o.authConfig)
+	if err != nil {
+		log.Fatalf("Failed to load slack auth config: %v.\n", err)
 	}
 
 	r := reconciler.New(slack.New(sc), p.Config)

--- a/tempelis/main.go
+++ b/tempelis/main.go
@@ -33,7 +33,6 @@ type options struct {
 	config       string
 	restrictions string
 	authConfig   string
-	validate     bool
 }
 
 func parseOptions() options {
@@ -43,7 +42,6 @@ func parseOptions() options {
 	flag.StringVar(&o.config, "config", "", "path to a configuration file, or directory of files")
 	flag.StringVar(&o.restrictions, "restrictions", "", "path to a configuration file containing restrictions")
 	flag.StringVar(&o.authConfig, "auth", "", "path to slack auth")
-	flag.BoolVar(&o.validate, "validate", false, "if set, we just validate the config and exit (offline)")
 	flag.Parse()
 	return o
 }
@@ -78,7 +76,6 @@ func main() {
 		return
 	}
 
-	// Normal mode: load auth and reconcile
 	sc, err := slack.LoadConfig(o.authConfig)
 	if err != nil {
 		log.Fatalf("Failed to load slack auth config: %v.\n", err)

--- a/tempelis/main.go
+++ b/tempelis/main.go
@@ -32,6 +32,7 @@ type options struct {
 	config       string
 	restrictions string
 	authConfig   string
+	validate     bool
 }
 
 func parseOptions() options {
@@ -40,6 +41,7 @@ func parseOptions() options {
 	flag.StringVar(&o.config, "config", "", "path to a configuration file, or directory of files")
 	flag.StringVar(&o.restrictions, "restrictions", "", "path to a configuration file containing restrictions")
 	flag.StringVar(&o.authConfig, "auth", "", "path to slack auth")
+	flag.BoolVar(&o.validate, "validate", false, "if set, we just validate the config and exit (offline)")
 	flag.Parse()
 	return o
 }
@@ -47,9 +49,14 @@ func parseOptions() options {
 func main() {
 	o := parseOptions()
 
-	sc, err := slack.LoadConfig(o.authConfig)
-	if err != nil {
-		log.Fatalf("Failed to load slack auth config: %v.\n", err)
+	var sc slack.Config
+	var err error
+
+	if !o.validate {
+		sc, err = slack.LoadConfig(o.authConfig)
+		if err != nil {
+			log.Fatalf("Failed to load slack auth config: %v.\n", err)
+		}
 	}
 
 	stat, err := os.Stat(o.config)
@@ -71,6 +78,11 @@ func main() {
 	}
 	if err != nil {
 		log.Fatalf("Failed to load config: %v\n", err)
+	}
+
+	if o.validate {
+		log.Println("Config valid!")
+		return
 	}
 
 	r := reconciler.New(slack.New(sc), p.Config)


### PR DESCRIPTION
This PR adds a --validate flag to tempelis for offline config validation. Fixes #65