### PR TITLE
use production images from registry.k8s.io in sample deployments

### DIFF
--- a/cluster/slack-event-log/deployment.yaml
+++ b/cluster/slack-event-log/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-event-log
-        image: gcr.io/k8s-staging-slack-infra/slack-event-log:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-event-log:v20230228-2b433f6
         args:
           - --config-path=/etc/slack-event-log/config.json
         ports:

--- a/cluster/slack-moderator-words/deployment.yaml
+++ b/cluster/slack-moderator-words/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator-words
-        image: gcr.io/k8s-staging-slack-infra/slack-moderator-words:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-moderator-words:v20230228-2b433f6
         imagePullPolicy: Always
         args:
           - --config-path=/etc/slack-moderator-words/config.json

--- a/cluster/slack-moderator/deployment.yaml
+++ b/cluster/slack-moderator/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator
-        image: gcr.io/k8s-staging-slack-infra/slack-moderator:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-moderator:v20230228-2b433f6
         args:
           - --config-path=/etc/slack-moderator/config.json
         ports:

--- a/cluster/slack-post-message/deployment.yaml
+++ b/cluster/slack-post-message/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-post-message
-        image: gcr.io/k8s-staging-slack-infra/slack-post-message:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-post-message:v20210223-8525eb3
         args:
           - --config-path=/etc/slack-post-message/config.json
         ports:

--- a/cluster/slack-welcomer/deployment.yaml
+++ b/cluster/slack-welcomer/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator
-        image: gcr.io/k8s-staging-slack-infra/slack-welcomer:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-welcomer:v20230228-2b433f6
         args:
           - --config-path=/etc/slack-welcomer/config.json
           - --message-path=/etc/welcome-message/welcome.md

--- a/cluster/slackin/deployment.yaml
+++ b/cluster/slackin/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slackin2
-        image: gcr.io/k8s-staging-slack-infra/slackin-kubernetes@sha256:c8ddc4ea1b07519878bb862cee7fc405dbdea74680e1f48b4649ec3bed18e564
+        image: registry.k8s.io/slack-infra/slackin-kubernetes:v20210510-e5e9992
         env:
         - name: PORT
           value: "80"


### PR DESCRIPTION
Update sample deployments in the `cluster/` directory to use production images from `registry.k8s.io/slack-infra/`.

This PR is part of the effort to migrate from staging GCR to production registry.k8s.io.
Promotion PR in `k8s.io`: https://github.com/kubernetes/k8s.io/pull/9213

Note: `slack-post-message` is updated to the production registry path but still needs its SHA to be added to the promoter manifest in `k8s.io` if not already there.

Fixes #66

/sig contributor-experience
/area infra
/assign @BenTheElder @cpanato @jeefy @nikhita @spiffxp