### PR TITLE
slack-welcomer: fix ingress API, update welcome message, fix container name

### DIFF
--- a/cluster/ingress.yaml
+++ b/cluster/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress
@@ -10,22 +10,37 @@ spec:
     - http:
         paths:
           - path: /infra/event-log/*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: slack-event-log
-              servicePort: 80
+              service:
+                name: slack-event-log
+                port:
+                  number: 80
           - path: /infra/moderator/*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: slack-moderator
-              servicePort: 80
+              service:
+                name: slack-moderator
+                port:
+                  number: 80
           - path: /infra/moderator-words/*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: slack-moderator-words
-              servicePort: 80
+              service:
+                name: slack-moderator-words
+                port:
+                  number: 80
           - path: /infra/welcomer/*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: slack-welcomer
-              servicePort: 80
+              service:
+                name: slack-welcomer
+                port:
+                  number: 80
           - path: /infra/post-message/*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: slack-post-message
-              servicePort: 80
+              service:
+                name: slack-post-message
+                port:
+                  number: 80

--- a/cluster/slack-welcomer/deployment.yaml
+++ b/cluster/slack-welcomer/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: slack-welcomer
     spec:
       containers:
-      - name: slack-moderator
+      - name: slack-welcomer
         image: registry.k8s.io/slack-infra/slack-welcomer:v20230228-2b433f6
         args:
           - --config-path=/etc/slack-welcomer/config.json

--- a/cluster/slack-welcomer/message.yaml
+++ b/cluster/slack-welcomer/message.yaml
@@ -4,32 +4,27 @@ metadata:
   name: slack-welcomer-message
 data:
   welcome.md: |-
-    Welcome to the Kubernetes Community Slack!
-
-    The Kubernetes Slack can be a large and intimidating place, please don't be afraid to ask questions. The community is quite welcoming :)
-    To ensure Slack remains a welcoming place for all, the Kubernetes Community adheres to a <https://git.k8s.io/community/code-of-conduct.md|Code of Conduct>.
-
-    *Have a general Kubernetes question?*
+    :kubernetes-intensifies: Welcome to the Kubernetes Community Slack!
+    We are so glad you are here! This is a friendly and supportive community — feel free to ask questions, share ideas, and connect with contributors from all over the world. :wave:
+    Before posting, please take a moment to read our <https://github.com/kubernetes/community/blob/main/communication/slack-guidelines.md|Slack Guidelines> and our <https://github.com/kubernetes/community/blob/main/code-of-conduct.md|Code of Conduct> so we can keep this space welcoming for everyone. :heart:
+    *Have a general Kubernetes question?* :thought_balloon:
     - Ask your question on the <https://discuss.kubernetes.io|official Kubernetes Forum>.
-    - Join #kubernetes-novice.
-    - Have your question answered live on stream in #office-hours during the monthly <https://git.k8s.io/community/events/office-hours.md|Office Hours>.
-    - Find a  <https://git.k8s.io/community/sig-list.md|SIG channel> to join and ask your question.
-
-    *Looking to contribute?*
-    - Ask questions in  #kubernetes-dev.
-    - Join a <https://git.k8s.io/community/sig-list.md|SIG channel>.
-    - Have your question answered live  on stream in #meet-our-contributors during the monthly <https://git.k8s.io/community/meet-our-contributors.md|MoC>.
+    - Join #sig-contribex-comms and say hello!
+    - Have your question answered live on stream in #office-hours during the monthly Office Hours.
+    - Find a <https://github.com/kubernetes/community/blob/main/sig-list.md|SIG channel> to join and ask your question.
+    *Looking to contribute?* :rocket:
+    - New to Kubernetes? Attend a <https://www.kubernetes.dev/docs/orientation/|New Contributor Orientation> — a great place to get started and meet the community!
+    - SIG Docs and Contributor Experience are excellent starting points.
+    - Explore the <https://github.com/kubernetes/community/blob/main/contributors/guide/README.md|Contributor Guide> and <https://github.com/kubernetes/community/blob/main/contributors/devel/README.md|Developer Guide>.
+    - Ask questions in #kubernetes-new-contributors.
+    - Join a <https://github.com/kubernetes/community/blob/main/sig-list.md|SIG channel>.
     - Have a PR you need reviewed? Hop into #pr-reviews to get some feedback.
-
-    *See some spam? or being harrassed?*
-    - Use the _"<https://git.k8s.io/community/communication/slack-guidelines.md#escalating-andor-reporting-a-problem|Report Message>"_ message action.
+    *See some spam? or being harassed?* :shield:
+    - Use the _"Report Message"_ message action.
     - Escalate by joining #slack-admins and ask for an Admin's assistance.
-
-    *Looking to join a local community?*
-    - There are many channels for regions and meetups, look for channels like `#meetup-[region]` or `#[region]-users`.
-
-    *Other channels of note:*
-    - #kubecon - Get your question answered about any upcoming <https://www.cncf.io/community/kubecon-cloudnativecon-events/|KubeCon/CloudNativeCon>.
+    *Other channels of note:* :loudspeaker:
+    - #kubecon - Get your question answered about any upcoming KubeCon/CloudNativeCon.
     - #kubernetes-careers - A place to post Kubernetes related jobs.
-
-    Have any other questions? Please see the <http://git.k8s.io/community/communication/slack-guidelines.md|Slack communications guidelines> to start.
+    - #sig-contribex - Connect with the Contributor Experience SIG.
+    - #kubernetes-new-contributors - A welcoming space just for newcomers! :seedling:
+    Have any other questions? Please see the <https://github.com/kubernetes/community/blob/main/communication/slack-guidelines.md|Slack Guidelines> to start. We are happy you are here! :tada:


### PR DESCRIPTION
This PR migrates `cluster/ingress.yaml` from the deprecated `extensions/v1beta1` to `networking.k8s.io/v1` with updated backend syntax, replaces all broken `git.k8s.io` links in `message.yaml` with working GitHub paths while adding the Slack Guidelines and updating channels, also fixes a container naming typo in `deployment.yaml` where the container was labeled `slack-moderator` instead of `slack-welcomer`.

/sig contributor-experience
/cc @jberkus @mrbobbytables @BenTheElder @Priyankasaggu11929

Fixes #76