### PR TITLE
slack-welcomer: add workflow-only moderation for #kubernetes-careers

### DIFF
--- a/slack-welcomer/handler.go
+++ b/slack-welcomer/handler.go
@@ -131,17 +131,21 @@ func (h *handler) handleEvent(body []byte) ([]byte, error) {
 	case "message":
 		event := struct {
 			Event struct {
-				SubType string `json:"subtype"`
-				User    string `json:"user"`
-				Channel string `json:"channel"`
-				Ts      string `json:"ts"`
-				BotID   string `json:"bot_id"`
+				SubType  string `json:"subtype"`
+				User     string `json:"user"`
+				Channel  string `json:"channel"`
+				Ts       string `json:"ts"`
+				ThreadTS string `json:"thread_ts"`
+				BotID    string `json:"bot_id"`
 			} `json:"event"`
 		}{}
 		if err := json.Unmarshal(body, &event); err != nil {
 			return nil, fmt.Errorf("failed to parse JSON: %v", err)
 		}
 		if event.Event.BotID != "" || event.Event.SubType == "bot_message" {
+			return []byte{}, nil
+		}
+		if event.Event.ThreadTS != "" && event.Event.ThreadTS != event.Event.Ts {
 			return []byte{}, nil
 		}
 		if h.isGuardedChannel(event.Event.Channel) && event.Event.User != "" {

--- a/slack-welcomer/handler.go
+++ b/slack-welcomer/handler.go
@@ -107,32 +107,46 @@ func (h *handler) handleURLVerification(body []byte) ([]byte, error) {
 }
 
 func (h *handler) handleEvent(body []byte) ([]byte, error) {
-	event := struct {
+	t := struct {
 		Event struct {
-			Type    string     `json:"type"`
-			SubType string     `json:"subtype"`
-			User    slack.User `json:"user"`
-			UserID  string     `json:"user_id"`
-			Channel string     `json:"channel"`
-			Ts      string     `json:"ts"`
-			BotID   string     `json:"bot_id"`
+			Type string `json:"type"`
 		} `json:"event"`
 	}{}
-	if err := json.Unmarshal(body, &event); err != nil {
+	if err := json.Unmarshal(body, &t); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %v", err)
 	}
 
-	switch event.Event.Type {
+	switch t.Event.Type {
 	case "team_join":
+		event := struct {
+			Event struct {
+				User slack.User `json:"user"`
+			} `json:"event"`
+		}{}
+		if err := json.Unmarshal(body, &event); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON: %v", err)
+		}
 		if err := h.sendWelcome(event.Event.User.ID); err != nil {
 			return nil, fmt.Errorf("failed to send welcome: %v", err)
 		}
 	case "message":
+		event := struct {
+			Event struct {
+				SubType string `json:"subtype"`
+				User    string `json:"user"`
+				Channel string `json:"channel"`
+				Ts      string `json:"ts"`
+				BotID   string `json:"bot_id"`
+			} `json:"event"`
+		}{}
+		if err := json.Unmarshal(body, &event); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON: %v", err)
+		}
 		if event.Event.BotID != "" || event.Event.SubType == "bot_message" {
 			return []byte{}, nil
 		}
-		if guardedChannels[event.Event.Channel] && event.Event.UserID != "" {
-			if err := h.enforceWorkflowOnly(event.Event.Channel, event.Event.UserID, event.Event.Ts); err != nil {
+		if guardedChannels[event.Event.Channel] && event.Event.User != "" {
+			if err := h.enforceWorkflowOnly(event.Event.Channel, event.Event.User, event.Event.Ts); err != nil {
 				return nil, fmt.Errorf("failed to enforce channel rules: %v", err)
 			}
 		}

--- a/slack-welcomer/handler.go
+++ b/slack-welcomer/handler.go
@@ -22,13 +22,25 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"time"
 
 	"sigs.k8s.io/slack-infra/slack"
 )
 
+var guardedChannels = map[string]bool{
+	"C25QWBR71": true, // #kubernetes-careers
+}
+
+const workflowNotice = `Hi there! Your message in <#%s> was removed because that channel only accepts posts submitted via the official workflow.
+
+To post a job listing or resume, please use the workflow shortcut (:zap:) in that channel.
+
+If you have questions, reach out in #slack-admins.`
+
 type handler struct {
 	client      *slack.Client
 	messagePath string
+	adminToken  string
 }
 
 func logError(rw http.ResponseWriter, format string, args ...interface{}) {
@@ -39,7 +51,6 @@ func logError(rw http.ResponseWriter, format string, args ...interface{}) {
 
 type handlerFunc func(body []byte) ([]byte, error)
 
-// ServeHTTP handles Slack webhook requests.
 func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -98,24 +109,129 @@ func (h *handler) handleURLVerification(body []byte) ([]byte, error) {
 func (h *handler) handleEvent(body []byte) ([]byte, error) {
 	event := struct {
 		Event struct {
-			Type string     `json:"type"`
-			User slack.User `json:"user"`
+			Type    string     `json:"type"`
+			SubType string     `json:"subtype"`
+			User    slack.User `json:"user"`
+			UserID  string     `json:"user_id"`
+			Channel string     `json:"channel"`
+			Ts      string     `json:"ts"`
+			BotID   string     `json:"bot_id"`
 		} `json:"event"`
 	}{}
 	if err := json.Unmarshal(body, &event); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %v", err)
 	}
 
-	// We should only be getting team_join events, but be sure to filter out anything else.
-	// We don't consider this an error, because Slack might get upset if we did.
-	if event.Event.Type != "team_join" {
-		return []byte{}, nil
+	switch event.Event.Type {
+	case "team_join":
+		if err := h.sendWelcome(event.Event.User.ID); err != nil {
+			return nil, fmt.Errorf("failed to send welcome: %v", err)
+		}
+	case "message":
+		if event.Event.BotID != "" || event.Event.SubType == "bot_message" {
+			return []byte{}, nil
+		}
+		if guardedChannels[event.Event.Channel] && event.Event.UserID != "" {
+			if err := h.enforceWorkflowOnly(event.Event.Channel, event.Event.UserID, event.Event.Ts); err != nil {
+				return nil, fmt.Errorf("failed to enforce channel rules: %v", err)
+			}
+		}
 	}
 
-	if err := h.sendWelcome(event.Event.User.ID); err != nil {
-		return nil, fmt.Errorf("failed to send welcome: %v", err)
-	}
 	return []byte{}, nil
+}
+
+func (h *handler) getUserInfo(id string) (slack.User, error) {
+	user := struct {
+		User slack.User `json:"user"`
+	}{}
+	if err := h.client.CallOldMethod("users.info", map[string]string{"user": id}, &user); err != nil {
+		return slack.User{}, fmt.Errorf("failed get user: %v", err)
+	}
+	return user.User, nil
+}
+
+func (h *handler) userIsAdmin(id string) (bool, error) {
+	user, err := h.getUserInfo(id)
+	if err != nil {
+		log.Printf("Failed to look up admin status: %v\n", err)
+		return false, err
+	}
+	return user.IsAdmin || user.IsOwner || user.IsPrimaryOwner, nil
+}
+
+func (h *handler) enforceWorkflowOnly(channel, userID, ts string) error {
+	admin, err := h.userIsAdmin(userID)
+	if err != nil {
+		log.Printf("Could not verify admin status for user %s, allowing post: %v\n", userID, err)
+		return nil
+	}
+	if admin {
+		return nil
+	}
+
+	log.Printf("Removing direct post from user %s in channel %s\n", userID, channel)
+
+	adminClient := slack.New(slack.Config{
+		AccessToken:   h.adminToken,
+		SigningSecret: h.client.Config.SigningSecret,
+	})
+
+	req := map[string]interface{}{
+		"channel": channel,
+		"ts":      ts,
+		"as_user": true,
+	}
+	for {
+		err := adminClient.CallMethod("chat.delete", req, nil)
+		if err == nil {
+			break
+		}
+		switch e := err.(type) {
+		case slack.ErrRateLimit:
+			log.Printf("Slack is rate limiting us, trying again in %s...\n", e.Wait)
+			time.Sleep(e.Wait)
+		case slack.ErrSlack:
+			if e.Type == "message_not_found" {
+				log.Printf("Message to delete not found, probably already deleted.\n")
+				return nil
+			}
+			return err
+		default:
+			return err
+		}
+	}
+
+	if err := h.notifyUser(userID, channel); err != nil {
+		log.Printf("Deleted message but failed to DM user %s: %v\n", userID, err)
+	}
+	return nil
+}
+
+func (h *handler) notifyUser(userID, channelID string) error {
+	response := struct {
+		Channel struct {
+			ID string `json:"id"`
+		} `json:"channel"`
+	}{}
+	if err := h.client.CallMethod("conversations.open", map[string]string{"users": userID}, &response); err != nil {
+		return fmt.Errorf("couldn't open a conversation channel: %v", err)
+	}
+	message := struct {
+		Channel   string `json:"channel"`
+		Text      string `json:"text"`
+		AsUser    bool   `json:"as_user"`
+		LinkNames bool   `json:"link_names"`
+	}{
+		Channel:   response.Channel.ID,
+		Text:      fmt.Sprintf(workflowNotice, channelID),
+		AsUser:    true,
+		LinkNames: true,
+	}
+	if err := h.client.CallMethod("chat.postMessage", message, nil); err != nil {
+		return fmt.Errorf("failed to send message: %v", err)
+	}
+	return nil
 }
 
 func (h *handler) sendWelcome(uid string) error {
@@ -124,7 +240,6 @@ func (h *handler) sendWelcome(uid string) error {
 		return fmt.Errorf("couldn't get welcome: %v", err)
 	}
 
-	// Slack requires that we first open a "conversation channel" that we can then use to actually send messages.
 	response := struct {
 		Channel struct {
 			ID string `json:"id"`

--- a/slack-welcomer/handler.go
+++ b/slack-welcomer/handler.go
@@ -27,20 +27,19 @@ import (
 	"sigs.k8s.io/slack-infra/slack"
 )
 
-var guardedChannels = map[string]bool{
-	"C25QWBR71": true, // #kubernetes-careers
-}
-
-const workflowNotice = `Hi there! Your message in <#%s> was removed because that channel only accepts posts submitted via the official workflow.
+const (
+	workflowNotice = `Hi there! Your message in <#%s> was removed because that channel only accepts posts submitted via the official workflow.
 
 To post a job listing or resume, please use the workflow shortcut (:zap:) in that channel.
 
 If you have questions, reach out in #slack-admins.`
 
+	maxRetries = 5
+)
+
 type handler struct {
 	client      *slack.Client
 	messagePath string
-	adminToken  string
 }
 
 func logError(rw http.ResponseWriter, format string, args ...interface{}) {
@@ -145,7 +144,7 @@ func (h *handler) handleEvent(body []byte) ([]byte, error) {
 		if event.Event.BotID != "" || event.Event.SubType == "bot_message" {
 			return []byte{}, nil
 		}
-		if guardedChannels[event.Event.Channel] && event.Event.User != "" {
+		if h.isGuardedChannel(event.Event.Channel) && event.Event.User != "" {
 			if err := h.enforceWorkflowOnly(event.Event.Channel, event.Event.User, event.Event.Ts); err != nil {
 				return nil, fmt.Errorf("failed to enforce channel rules: %v", err)
 			}
@@ -153,6 +152,15 @@ func (h *handler) handleEvent(body []byte) ([]byte, error) {
 	}
 
 	return []byte{}, nil
+}
+
+func (h *handler) isGuardedChannel(channel string) bool {
+	for _, c := range h.client.Config.GuardedChannels {
+		if c == channel {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *handler) getUserInfo(id string) (slack.User, error) {
@@ -187,7 +195,7 @@ func (h *handler) enforceWorkflowOnly(channel, userID, ts string) error {
 	log.Printf("Removing direct post from user %s in channel %s\n", userID, channel)
 
 	adminClient := slack.New(slack.Config{
-		AccessToken:   h.adminToken,
+		AccessToken:   h.client.Config.AdminToken,
 		SigningSecret: h.client.Config.SigningSecret,
 	})
 
@@ -196,13 +204,16 @@ func (h *handler) enforceWorkflowOnly(channel, userID, ts string) error {
 		"ts":      ts,
 		"as_user": true,
 	}
-	for {
+	for i := 0; i < maxRetries; i++ {
 		err := adminClient.CallMethod("chat.delete", req, nil)
 		if err == nil {
 			break
 		}
 		switch e := err.(type) {
 		case slack.ErrRateLimit:
+			if i == maxRetries-1 {
+				return fmt.Errorf("rate limit exceeded after %d retries: %v", maxRetries, err)
+			}
 			log.Printf("Slack is rate limiting us, trying again in %s...\n", e.Wait)
 			time.Sleep(e.Wait)
 		case slack.ErrSlack:

--- a/slack-welcomer/main.go
+++ b/slack-welcomer/main.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -43,9 +45,7 @@ func handleHealthz(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("ok"))
 }
 
-func runServer(sl *slack.Client, o options) {
-	h := &handler{client: sl, messagePath: o.messagePath}
-
+func runServer(h *handler) error {
 	http.HandleFunc("/healthz", handleHealthz)
 	http.Handle(os.Getenv("PATH_PREFIX")+"/webhook", h)
 
@@ -56,7 +56,21 @@ func runServer(sl *slack.Client, o options) {
 	}
 
 	log.Printf("Listening on port %s", port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+	return http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+}
+
+func loadAdminToken(path string) (string, error) {
+	extraConf := struct {
+		AdminToken string `json:"adminToken"`
+	}{}
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("couldn't open file: %v", err)
+	}
+	if err := json.Unmarshal(content, &extraConf); err != nil {
+		return "", fmt.Errorf("couldn't parse config: %v", err)
+	}
+	return extraConf.AdminToken, nil
 }
 
 func main() {
@@ -65,6 +79,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to load config from %s: %v", o.configPath, err)
 	}
+	adminToken, err := loadAdminToken(o.configPath)
+	if err != nil {
+		log.Fatalf("Failed to load admin token from %s: %v", o.configPath, err)
+	}
 	s := slack.New(c)
-	runServer(s, o)
+
+	h := &handler{client: s, messagePath: o.messagePath, adminToken: adminToken}
+	log.Fatal(runServer(h))
 }

--- a/slack-welcomer/main.go
+++ b/slack-welcomer/main.go
@@ -17,10 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -59,32 +57,20 @@ func runServer(h *handler) error {
 	return http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
 }
 
-func loadAdminToken(path string) (string, error) {
-	extraConf := struct {
-		AdminToken string `json:"adminToken"`
-	}{}
-	content, err := ioutil.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("couldn't open file: %v", err)
-	}
-	if err := json.Unmarshal(content, &extraConf); err != nil {
-		return "", fmt.Errorf("couldn't parse config: %v", err)
-	}
-	return extraConf.AdminToken, nil
-}
-
 func main() {
 	o := parseFlags()
 	c, err := slack.LoadConfig(o.configPath)
 	if err != nil {
 		log.Fatalf("Failed to load config from %s: %v", o.configPath, err)
 	}
-	adminToken, err := loadAdminToken(o.configPath)
-	if err != nil {
-		log.Fatalf("Failed to load admin token from %s: %v", o.configPath, err)
+	if c.AdminToken == "" {
+		log.Fatalf("adminToken is required but was not found in %s", o.configPath)
+	}
+	if len(c.GuardedChannels) == 0 {
+		log.Fatalf("guardedChannels is required but was not found in %s", o.configPath)
 	}
 	s := slack.New(c)
 
-	h := &handler{client: s, messagePath: o.messagePath, adminToken: adminToken}
+	h := &handler{client: s, messagePath: o.messagePath}
 	log.Fatal(runServer(h))
 }

--- a/slack/config.go
+++ b/slack/config.go
@@ -24,9 +24,11 @@ import (
 
 // Config is the information needed to communicate with Slack.
 type Config struct {
-	SigningSecret string `json:"signingSecret"`
-	WebhookURL    string `json:"webhook"`
-	AccessToken   string `json:"accessToken"`
+	SigningSecret   string   `json:"signingSecret"`
+	WebhookURL      string   `json:"webhook"`
+	AccessToken     string   `json:"accessToken"`
+	AdminToken      string   `json:"adminToken"`
+	GuardedChannels []string `json:"guardedChannels"`
 }
 
 // LoadConfig loads a Config from a JSON file.


### PR DESCRIPTION

This PR adds message moderation to the `slack-welcomer` app so it can automatically remove direct posts in `#kubernetes-careers` and enforce the channel's workflow rules. 

### Changes
* **main.go**: Added support for an admin token (`adminToken`) alongside the normal bot token so the app has permission to delete messages.
* **handler.go**: Fixed JSON parsing to correctly extract the user ID for both `team_join` and `message` events, added logic to catch and delete unapproved direct posts while messaging the user, and included a back-off retry loop to handle Slack rate limits gracefully.

/sig contributor-experience
cc: @jberkus  @mrbobbytables 
