### PR TITLE
tempelis: validate usergroup member names in --validate-only mode

### DIFF
--- a/tempelis/main.go
+++ b/tempelis/main.go
@@ -72,6 +72,14 @@ func main() {
 
 	// If validate-only mode, just validate the config and exit
 	if o.validateOnly {
+		for _, g := range p.Config.Usergroups {
+			if g.External {
+				continue
+			}
+			if _, err := p.Config.NamesToIDs(g.Members); err != nil {
+				log.Fatalf("usergroup %q has invalid member(s): %v\n", g.Name, err)
+			}
+		}
 		log.Println("Configuration validation successful!")
 		return
 	}


### PR DESCRIPTION

`--validate-only` mode doesn't check that usergroup members actually exist in `users.yaml`. It only checks structural stuff like  name, description, having at least one member so a typo'd member name slips through presubmit and only fails later, when the change is actually applied to Slack.

This adds that name check into `--validate-only` mode. It doesn't need a live Slack connection, since it's just comparing against the local `users.yaml` mapping, so it fits the reason `--validate-only` exists in the first place: catching config errors without needing a credential.