### PR TITLE
tempelis: validate description length and handle/channel collisions offline

### DIFF
--- a/tempelis/config/config.go
+++ b/tempelis/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 type Config struct {
@@ -79,4 +80,33 @@ func (c *Config) NamesToIDs(names []string) ([]string, error) {
 		return nil, fmt.Errorf("unknown user names: %s", strings.Join(missing, ", "))
 	}
 	return result, nil
+}
+
+// maxUsergroupDescription is Slack's limit; exceeding it fails usergroups.create/update with description_too_long.
+const maxUsergroupDescription = 140
+
+// Validate checks constraints that Slack enforces at apply time but that can be
+// verified offline: member names resolve, descriptions fit, and handles do not
+// collide with channel names (usergroup handles and channel names share one
+// namespace, so usergroups.create fails with handle_already_exists).
+func (c *Config) Validate() error {
+	channels := map[string]struct{}{}
+	for _, ch := range c.Channels {
+		channels[ch.Name] = struct{}{}
+	}
+	for _, g := range c.Usergroups {
+		if g.External {
+			continue
+		}
+		if _, err := c.NamesToIDs(g.Members); err != nil {
+			return fmt.Errorf("usergroup %q has invalid member(s): %v", g.Name, err)
+		}
+		if n := utf8.RuneCountInString(g.Description); n > maxUsergroupDescription {
+			return fmt.Errorf("usergroup %q description is %d characters, Slack allows at most %d", g.Name, n, maxUsergroupDescription)
+		}
+		if _, ok := channels[g.Name]; ok {
+			return fmt.Errorf("usergroup %q has the same name as a channel; Slack rejects usergroup handles that match channel names", g.Name)
+		}
+	}
+	return nil
 }

--- a/tempelis/config/validate_test.go
+++ b/tempelis/config/validate_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			Users:    map[string]string{"alice": "U1"},
+			Channels: []Channel{{Name: "some-channel"}},
+		}
+	}
+	tests := []struct {
+		name    string
+		group   Usergroup
+		wantErr string
+	}{
+		{"ok", Usergroup{Name: "some-group", Description: "fine", Members: []string{"alice"}}, ""},
+		{"unknown member", Usergroup{Name: "g", Description: "fine", Members: []string{"bob"}}, "unknown user names: bob"},
+		{"description too long", Usergroup{Name: "g", Description: strings.Repeat("á", 141), Members: []string{"alice"}}, "141 characters"},
+		{"handle equals channel", Usergroup{Name: "some-channel", Description: "fine", Members: []string{"alice"}}, "same name as a channel"},
+		{"external skipped", Usergroup{Name: "some-channel", External: true}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := base()
+			c.Usergroups = []Usergroup{tc.group}
+			err := c.Validate()
+			if tc.wantErr == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/tempelis/main.go
+++ b/tempelis/main.go
@@ -70,16 +70,11 @@ func main() {
 		log.Fatalf("Failed to load config: %v\n", err)
 	}
 
-	// If validate-only mode, just validate the config and exit
+	if err := p.Config.Validate(); err != nil {
+		log.Fatalf("Invalid config: %v\n", err)
+	}
+
 	if o.validateOnly {
-		for _, g := range p.Config.Usergroups {
-			if g.External {
-				continue
-			}
-			if _, err := p.Config.NamesToIDs(g.Members); err != nil {
-				log.Fatalf("usergroup %q has invalid member(s): %v\n", g.Name, err)
-			}
-		}
 		log.Println("Configuration validation successful!")
 		return
 	}


### PR DESCRIPTION
Adds `Config.Validate()` and calls it in both `--validate-only` and before `Reconcile`. Checks, all offline:

- member names resolve (moved from `main.go`, added in #85)
- description ≤ 140 characters, counted as runes (Slack `description_too_long`)
- usergroup handle ≠ any channel name (Slack `handle_already_exists`; handles and channel names share a namespace)

### Motivation: 

`@release-comms` in kubernetes/community had three post-merge fixes (kubernetes/community#9133, #9137, #9156), each one failing in `post-community-tempelis-apply` after `pull-community-tempelis-check` passed. 

/cc @jberkus @mrbobbytables @cpanato

### AI Disclosure

This PR was written in part with the assistance of generative AI.

